### PR TITLE
Fix the issue of extra </span> after the image

### DIFF
--- a/picture_tag.rb
+++ b/picture_tag.rb
@@ -155,12 +155,14 @@ module Jekyll
         }
 
         # Note: we can't indent html output because markdown parsers will turn 4 spaces into code blocks
-        picture_tag = "<span #{html_attr_string}>\n"\
+        picture_tag = "{::nomarkdown}\n"\
+                      "<span #{html_attr_string}>\n"\
                       "#{source_tags}"\
                       "<noscript>\n"\
                       "<img src=\"#{instance['source_default'][:generated_src]}\" alt=\"#{html_attr['data-alt']}\">\n"\
                       "</noscript>\n"\
-                      "</span>\n"
+                      "</span>\n"\
+                      "{:/}\n"
 
       elsif settings['markup'] == 'picture'
 


### PR DESCRIPTION
It’s a know issue reported at
https://github.com/robwierzbowski/jekyll-picture-tag/issues/23

It is caused by the unwant `<p>` tag around the `<span>` tag.

As the markdown processing will wrap the `<span>` element with a `<p>` tag,
so use the {::nomarkdown} {:/} block to skip the markdown processing to
avoid the extra `<p>` tag.
