### PR TITLE
Update to native <picture> syntax (Picturefill 2.0)

### DIFF
--- a/examples/_config.yml
+++ b/examples/_config.yml
@@ -7,7 +7,7 @@ markdown: redcarpet
 picture:
   source: assets/images/_fullsize
   output: generated
-  markup: picturefill
+  markup: picture
   presets:
     # Full width pictures
     default:

--- a/examples/output.html
+++ b/examples/output.html
@@ -1,25 +1,11 @@
-<!-- Example picturefill output, {% picture portrait.jpg alt="An example of picturefill markup" %} -->
+<!-- Example picture output, {% picture portrait.jpg alt="An example of picturefill markup" %} -->
 
-<span class="picturefill" itemprop="image" data-picture data-alt="An example of picturefill markup" >
-<span data-src="/generated/portrait-350x200-28f3ea.jpg"></span>
-<span data-src="/generated/portrait-525x300-28f3ea.jpg" data-media="(-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi)"></span>
-<span data-src="/generated/portrait-450x304-28f3ea.jpg" data-media="(min-width: 30em)"></span>
-<span data-src="/generated/portrait-675x456-28f3ea.jpg" data-media="(min-width: 30em) and (-webkit-min-device-pixel-ratio: 1.5), (min-width: 30em) and (min-resolution: 144dpi)"></span>
-<span data-src="/generated/portrait-700x473-28f3ea.jpg" data-media="(min-width: 40em)"></span>
-<span data-src="/generated/portrait-1050x709-28f3ea.jpg" data-media="(min-width: 40em) and (-webkit-min-device-pixel-ratio: 1.5), (min-width: 40em) and (min-resolution: 144dpi)"></span>
-<noscript>
-<img src="/generated/portrait-350x200-28f3ea.jpg" alt="An example of picturefill markup">
-</noscript>
-</span>
-
-<!-- Example picture output, {% picture portrait.jpg alt="An example of picture markup" %} -->
-
-<picture class="picture" itemprop="image" alt="An example of picture markup" >
-<source src="/generated/portrait-1050x709-28f3ea.jpg" media="(min-width: 40em) and (-webkit-min-device-pixel-ratio: 1.5), (min-width: 40em) and (min-resolution: 144dpi)">
-<source src="/generated/portrait-700x473-28f3ea.jpg" media="(min-width: 40em)">
-<source src="/generated/portrait-675x456-28f3ea.jpg" media="(min-width: 30em) and (-webkit-min-device-pixel-ratio: 1.5), (min-width: 30em) and (min-resolution: 144dpi)">
-<source src="/generated/portrait-450x304-28f3ea.jpg" media="(min-width: 30em)">
-<source src="/generated/portrait-525x300-28f3ea.jpg" media="(-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi)">
-<img src="/generated/portrait-350x200-28f3ea.jpg" alt="An example of picture markup">
-<p>An example of picture markup</p>
+<picture>
+  <source srcset="/generated/portrait-1050by1050-092483.jpg" media="(min-width: 40em) and (-webkit-min-device-pixel-ratio: 1.5), (min-width: 40em) and (min-resolution: 144dpi)">
+  <source srcset="/generated/portrait-700by700-092483.jpg" media="(min-width: 40em)">
+  <source srcset="/generated/portrait-675by675-092483.jpg" media="(min-width: 30em) and (-webkit-min-device-pixel-ratio: 1.5), (min-width: 30em) and (min-resolution: 144dpi)">
+  <source srcset="/generated/portrait-450by450-092483.jpg" media="(min-width: 30em)">
+  <source srcset="/generated/portrait-525by300-092483.jpg" media="(-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi)">
+  <source srcset="/generated/portrait-350by200-092483.jpg">
+  <img srcset="/generated/portrait-350by200-092483.jpg" alt="">
 </picture>

--- a/examples/post.md
+++ b/examples/post.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: title: Tag examples
+title: Tag examples
 ---
 
 {% picture portrait.jpg alt="An unsual picture" %}
@@ -13,4 +13,4 @@ With a preset specified:
 {% picture gallery portrait.jpg alt="An unsual picture" data-downloadable="true" %}
 
 With an alternate source images:  
-{% picture gallery portrait.jpg source_lrg: dream-fullpage.jpg source_med: dream-midrange.jpg alt="An unsual picture" data-downloadable="true" %}
+{% picture half portrait.jpg source_lrg: dream-fullpage.jpg source_med: dream-midrange.jpg alt="An unsual picture" data-downloadable="true" %}

--- a/picture_tag.rb
+++ b/picture_tag.rb
@@ -146,41 +146,23 @@ module Jekyll
       }
 
       # Construct and return tag
-      if settings['markup'] == 'picturefill'
+      if settings['markup'] == 'picture'
 
         source_tags = ''
-        # Picturefill uses reverse source order
-        # Reference: https://github.com/scottjehl/picturefill/issues/79
-        source_keys.reverse.each { |source|
-          media = " data-media=\"#{instance[source]['media']}\"" unless source == 'source_default'
-          source_tags += "#{markdown_escape * 4}<span data-src=\"#{instance[source][:generated_src]}\"#{media}></span>\n"
+        source_keys.each { |source|
+          media = " media=\"#{instance[source]['media']}\"" unless source == 'source_default'
+          source_tags += "#{markdown_escape * 4}<source srcset=\"#{instance[source][:generated_src]}\"#{media}>\n"
         }
 
         # Note: we can't indent html output because markdown parsers will turn 4 spaces into code blocks
         # Note: Added backslash+space escapes to bypass markdown parsing of indented code below -WD
-        picture_tag = "<span #{html_attr_string}>\n"\
+        picture_tag = "<picture>\n"\
                       "#{source_tags}"\
-                      "#{markdown_escape * 4}<noscript>\n"\
-                      "#{markdown_escape * 6}<img src=\"#{instance['source_default'][:generated_src]}\" alt=\"#{html_attr['data-alt']}\">\n"\
-                      "#{markdown_escape * 4}</noscript>\n"\
-                      "#{markdown_escape * 2}</span>\n"
+                      "#{markdown_escape * 4}<img srcset=\"#{instance['source_default'][:generated_src]}\" alt=\"#{html_attr['data-alt']}\">\n"\
+                      "#{markdown_escape * 2}</picture>\n"
 
-      elsif settings['markup'] == 'picture'
-      
-        source_tags = ''
-        source_keys.each { |source|
-          if source == 'source_default'
-            source_tags +=  "#{markdown_escape * 4}<img src=\"#{instance[source][:generated_src]}\" alt=\"#{html_attr['alt']}\">\n"
-          else
-            source_tags += "#{markdown_escape * 4}<source src=\"#{instance[source][:generated_src]}\" media=\"#{instance[source]['media']}\">\n"
-          end
-        }
-
-        # Note: we can't indent html output because markdown parsers will turn 4 spaces into code blocks
-        picture_tag = "<picture #{html_attr_string}>\n"\
-                      "#{source_tags}"\
-                      "#{markdown_escape * 4}<p>#{html_attr['alt']}</p>\n"\
-                      "#{markdown_escape * 2}</picture>"
+      elsif settings['markup'] == 'img'
+        # TODO implement <img srcset/sizes>
       end
 
         # Return the markup!


### PR DESCRIPTION
Tested against Picturefill 2.0.0-beta and 2.1.0-beta.

I've messed with on my own site and using the code in `examples` but I'd love for someone else to give this a go to see if I missed a feature. It works in Firefox, Safari, Chrome, and Chrome Canary (which uses native `picture` rather than the polyfill).

A few future updates this doesn't include:
- Include the IE9 `<video>` hack, as show in http://scottjehl.github.io/picturefill
- Provide a `srcset/sizes` option in addition to `<picture>`.
