### PR TITLE
Loading images

### DIFF
--- a/lib/jekyll-picture-tag/output_formats/basics.rb
+++ b/lib/jekyll-picture-tag/output_formats/basics.rb
@@ -14,7 +14,7 @@ module PictureTag
         img.attributes << attributes['img']
         img.attributes << attributes['implicit']
 
-        fallback = build_fallback_image
+        fallback = build_fallback_image(PictureTag.fallback_width)
 
         add_src(img, fallback.name)
 
@@ -76,11 +76,11 @@ module PictureTag
       end
 
       # File, not HTML
-      def build_fallback_image
+      def build_fallback_image(width)
         GeneratedImage.new(
           source_file: PictureTag.source_images[nil],
           format: PictureTag.fallback_format,
-          width: PictureTag.fallback_width
+          width: width
         )
       end
 

--- a/lib/jekyll-picture-tag/output_formats/data_attributes.rb
+++ b/lib/jekyll-picture-tag/output_formats/data_attributes.rb
@@ -7,6 +7,14 @@ module PictureTag
         build_noscript(super)
       end
 
+      def build_base_img
+        img = super
+
+        add_temp_src img
+
+        img
+      end
+
       private
 
       def add_src(element, name)
@@ -38,6 +46,29 @@ module PictureTag
           # Markdown fix requires removal of line breaks:
           oneline: PictureTag.nomarkdown?
         )
+      end
+
+      # Looks at temp_src setting in preset. Adds either a generated image or
+      # the defined generic source image.
+      def add_temp_src(img)
+        return unless (preset_src = PictureTag.preset['temp_src'])
+
+        img.src = if preset_src.is_a? Integer
+                    generated_src preset_src
+                  else
+                    preset_src
+                  end
+      end
+
+      # Takes our fallback image and adds a very low res src
+      def generated_src(width)
+        image = GeneratedImage.new(
+          source_file: PictureTag.source_images[nil],
+          format: PictureTag.fallback_format,
+          width: width
+        )
+
+        PictureTag.build_url image.name
       end
     end
   end


### PR DESCRIPTION
Close #112 Close #113 

**Not ready to be merged yet, needs documentation and further testing.** This is a quick implementation of these feature suggestions, here's how it works:

Set a `temp_src` value in a `data_` preset. 
* If it's a number, it'll generate an image of that width and set it as the `src` attribute. Obviously you'd set this to some low number, and you'd have to scale it with CSS.
* If it's anything else (but probably a string), it just sets that to the src attribute. This will be relative to the site root, not the configured `output` directory. This also allows you to use placeholder images that aren't hosted on your own site.

