### PR TITLE
Nomarkdown mitigation

### DIFF
--- a/lib/jekyll_picture_tag/instructions.rb
+++ b/lib/jekyll_picture_tag/instructions.rb
@@ -76,10 +76,6 @@ module PictureTag
       @config.build_source_url(filename)
     end
 
-    def nomarkdown?
-      @config.nomarkdown?
-    end
-
     # Preset forwarding
     def widths(media)
       @preset.widths(media)
@@ -92,6 +88,11 @@ module PictureTag
     def fallback_width
       @preset.fallback_width
     end
+
+    def nomarkdown?
+      @preset.nomarkdown?
+    end
+
 
     # Params forwarding
     def preset_name

--- a/lib/jekyll_picture_tag/instructions/preset.rb
+++ b/lib/jekyll_picture_tag/instructions/preset.rb
@@ -27,6 +27,16 @@ module PictureTag
         @content['fallback_width']
       end
 
+      # Allows a per-preset hard override of the global nomarkdown setting and
+      # JPT's feeble attempts at auto-detection.
+      def nomarkdown?
+        if @content['nomarkdown'].nil?
+          PictureTag.config.nomarkdown?
+        else
+          @content['nomarkdown']
+        end
+      end
+
       private
 
       def build_preset

--- a/lib/jekyll_picture_tag/output_formats/basics.rb
+++ b/lib/jekyll_picture_tag/output_formats/basics.rb
@@ -32,7 +32,10 @@ module PictureTag
       # Handles various wrappers around basic markup
       def wrap(markup)
         markup = anchor_tag(markup) if PictureTag.html_attributes['link']
-        markup = nomarkdown_wrapper(markup.to_s) if PictureTag.nomarkdown?
+
+        if PictureTag.html_attributes['link'] && PictureTag.nomarkdown?
+          markup = nomarkdown_wrapper(markup.to_s)
+        end
 
         markup
       end

--- a/lib/jekyll_picture_tag/output_formats/basics.rb
+++ b/lib/jekyll_picture_tag/output_formats/basics.rb
@@ -31,10 +31,9 @@ module PictureTag
 
       # Handles various wrappers around basic markup
       def wrap(markup)
-        markup = anchor_tag(markup) if PictureTag.html_attributes['link']
-
-        if PictureTag.html_attributes['link'] && PictureTag.nomarkdown?
-          markup = nomarkdown_wrapper(markup.to_s)
+        if PictureTag.html_attributes['link']
+          markup = anchor_tag(markup)
+          markup = nomarkdown_wrapper(markup.to_s) if PictureTag.nomarkdown?
         end
 
         markup

--- a/lib/jekyll_picture_tag/version.rb
+++ b/lib/jekyll_picture_tag/version.rb
@@ -1,3 +1,3 @@
 module PictureTag
-  VERSION = '1.4.0'.freeze
+  VERSION = '1.5.0'.freeze
 end

--- a/readme.md
+++ b/readme.md
@@ -178,6 +178,9 @@ modifications and I'll take care of it.
 
 # Release History
 
+* 1.5.0 Jun 26, 2019: 
+  * better `{::nomarkdown}` necessity detection
+  * allow user to override `{::nomarkdown}` autodetection
 * 1.4.0 Jun 26, 2019:
   * Rename gem from `jekyll-picture-tag` to `jekyll_picture_tag`, allowing us to use rubygems again.
   * Add new output format: `naked_srcset`.


### PR DESCRIPTION
close #124 

Sadly, I haven't found a way to reliably detect when `{::nomarkdown}` tags are necessary. These changes take steps to reduce the frequency, and add a configuration setting to allow the user to override undesired behavior. 

I've written a [wiki page](https://github.com/rbuchberger/jekyll_picture_tag/wiki/Extra-%7B::nomarkdown%7D-tags-or-mangled-html%3F) detailing the issue.