### PR TITLE
Improve "preset not found" warning

### DIFF
--- a/lib/jekyll_picture_tag/instructions/preset.rb
+++ b/lib/jekyll_picture_tag/instructions/preset.rb
@@ -60,8 +60,8 @@ module PictureTag
 
       def no_preset
         Utils.warning(
-          " Preset \"#{@name}\" not found in _data/picture.yml under "\
-          'markup_presets key. Using default values.'
+          " Preset \"#{@name}\" not found in #{PictureTag.config['data_dir']}/"\
+          + 'picture.yml under markup_presets key. Using default values.'
         )
 
         {}


### PR DESCRIPTION
Display the jekyll data_dir setting, rather than hardcoding it to
the default.