### PR TITLE
Continue on missing

### DIFF
--- a/lib/jekyll_picture_tag/defaults/global.yml
+++ b/lib/jekyll_picture_tag/defaults/global.yml
@@ -6,6 +6,7 @@ picture:
   relative_url: true
   cdn_environments: ['production']
   nomarkdown: true
+  ignore_missing_images: false
 
 url: ''
 baseurl: ''

--- a/lib/jekyll_picture_tag/generated_image.rb
+++ b/lib/jekyll_picture_tag/generated_image.rb
@@ -11,7 +11,7 @@ class GeneratedImage
     @width  = width
     @format = format
 
-    generate_image unless skip_generation?
+    generate_image unless File.exist?(absolute_filename) || @source.missing
   end
 
   def name
@@ -26,10 +26,6 @@ class GeneratedImage
   end
 
   private
-
-  def skip_generation?
-    File.exist?(absolute_filename) || @source.missing
-  end
 
   def generate_image
     puts 'Generating new image file: ' + name

--- a/lib/jekyll_picture_tag/generated_image.rb
+++ b/lib/jekyll_picture_tag/generated_image.rb
@@ -4,12 +4,14 @@ class GeneratedImage
   require 'mini_magick'
   require 'fastimage'
 
+  attr_reader :width
+
   def initialize(source_file:, width:, format:)
     @source = source_file
     @width  = width
     @format = format
 
-    generate_image unless File.exist? absolute_filename
+    generate_image unless skip_generation?
   end
 
   def name
@@ -23,11 +25,11 @@ class GeneratedImage
     @absolute_filename ||= File.join(PictureTag.config.dest_dir, name)
   end
 
-  def width
-    @width
-  end
-
   private
+
+  def skip_generation?
+    File.exist?(absolute_filename) || @source.missing
+  end
 
   def generate_image
     puts 'Generating new image file: ' + name
@@ -45,7 +47,7 @@ class GeneratedImage
 
     image.write absolute_filename
 
-    FileUtils.chmod(0644, absolute_filename)
+    FileUtils.chmod(0o644, absolute_filename)
   end
 
   # Make sure destination directory exists

--- a/lib/jekyll_picture_tag/instructions/configuration.rb
+++ b/lib/jekyll_picture_tag/instructions/configuration.rb
@@ -14,7 +14,7 @@ module PictureTag
       # Digs into jekyll context, returns current environment
       def jekyll_env
         # It would be really great if the jekyll devs actually documented
-        # the context object. 
+        # the context object.
         PictureTag.context.environments.first['jekyll']['environment']
       end
 
@@ -51,6 +51,19 @@ module PictureTag
         Utils.markdown_page? && self['picture']['nomarkdown']
       end
 
+      def continue_on_missing?
+        setting = @content['picture']['ignore_missing_images']
+
+        # Config setting can be a string, an array, or a boolean
+        if setting.is_a? Array
+          setting.include? jekyll_env
+        elsif setting.is_a? String
+          setting == jekyll_env
+        else
+          setting
+        end
+      end
+
       private
 
       def build_config
@@ -84,14 +97,14 @@ module PictureTag
       # Juuust complicated enough to extract to its own function.
       def cdn?
         self['picture']['cdn_url'] &&
-          self['picture']['cdn_environments'].include?( jekyll_env )
+          self['picture']['cdn_environments'].include?(jekyll_env)
       end
 
       # https://example.com/my-base-path/assets/generated-images/image.jpg
       # ^^^^^^^^^^^^^^^^^^^^
       # |     domain       |  baseurl   |    j-p-t output dir   | filename
       def domain
-        if cdn? 
+        if cdn?
           self['picture']['cdn_url']
         elsif self['picture']['relative_url']
           ''
@@ -106,12 +119,11 @@ module PictureTag
       def url_prefix
         # We use file.join because the ruby url methods don't like relative
         # urls.
-          File.join(
-            domain,
-            self['baseurl'],
-          )
+        File.join(
+          domain,
+          self['baseurl']
+        )
       end
-
     end
   end
 end

--- a/lib/jekyll_picture_tag/source_image.rb
+++ b/lib/jekyll_picture_tag/source_image.rb
@@ -82,7 +82,8 @@ module PictureTag
       <<~HEREDOC
         Jekyll Picture Tag could not find #{source_name}. You can force the
         build to continue anyway by setting "picture: ignore_missing_images:
-        true" in "_config.yml"
+        true" in "_config.yml". This setting can also accept a jekyll build
+        environment, or an array of environments.
       HEREDOC
     end
   end

--- a/lib/jekyll_picture_tag/source_image.rb
+++ b/lib/jekyll_picture_tag/source_image.rb
@@ -62,13 +62,20 @@ module PictureTag
 
       elsif PictureTag.config.continue_on_missing?
         @missing = true
-        Utils.warning "Could not find #{source_name}. Continuing."
+        Utils.warning missing_image_warning(source_name)
 
       else
         raise missing_image_error(source_name)
       end
 
       source_name
+    end
+
+    def missing_image_warning(source_name)
+      <<~HEREDOC
+        Could not find #{source_name}. Your site will have broken images in it.
+        Continuing.
+      HEREDOC
     end
 
     def missing_image_error(source_name)

--- a/lib/jekyll_picture_tag/source_image.rb
+++ b/lib/jekyll_picture_tag/source_image.rb
@@ -3,7 +3,7 @@ module PictureTag
   # advantage by storing expensive file reads and writes in instance variables,
   # to be reused by many different source images.
   class SourceImage
-    attr_reader :name, :shortname
+    attr_reader :name, :shortname, :missing
 
     def initialize(relative_filename)
       @shortname = relative_filename
@@ -18,12 +18,12 @@ module PictureTag
       size[:width]
     end
 
-    def aspect_ratio
-      @aspect_ratio ||= size[:width].to_f / size[:height].to_f
-    end
-
     def digest
-      @digest ||= Digest::MD5.hexdigest(File.read(@name))[0..5]
+      @digest ||= if @missing
+                    'x' * 6
+                  else
+                    Digest::MD5.hexdigest(File.read(@name))[0..5]
+                  end
     end
 
     # Includes path relative to default sorce folder, and the original filename.
@@ -40,7 +40,12 @@ module PictureTag
     private
 
     def build_size
-      width, height = FastImage.size(@name)
+      if @missing
+        width = 999_999
+        height = 999_999
+      else
+        width, height = FastImage.size(@name)
+      end
 
       {
         width: width,
@@ -52,11 +57,26 @@ module PictureTag
     def grab_file(source_file)
       source_name = File.join(PictureTag.config.source_dir, source_file)
 
-      unless File.exist? source_name
-        raise "Jekyll Picture Tag could not find #{source_name}."
+      if File.exist? source_name
+        @missing = false
+
+      elsif PictureTag.config['picture']['ignore_missing_images']
+        @missing = true
+        Utils.warning "Could not find #{source_name}. Continuing."
+
+      else
+        raise missing_image_error(source_name)
       end
 
       source_name
+    end
+
+    def missing_image_error(source_name)
+      <<~HEREDOC
+        Jekyll Picture Tag could not find #{source_name}. You can force the
+        build to continue anyway by setting "picture: ignore_missing_images:
+        true" in "_config.yml"
+      HEREDOC
     end
   end
 end

--- a/lib/jekyll_picture_tag/source_image.rb
+++ b/lib/jekyll_picture_tag/source_image.rb
@@ -60,7 +60,7 @@ module PictureTag
       if File.exist? source_name
         @missing = false
 
-      elsif PictureTag.config['picture']['ignore_missing_images']
+      elsif PictureTag.config.continue_on_missing?
         @missing = true
         Utils.warning "Could not find #{source_name}. Continuing."
 


### PR DESCRIPTION
close #37

This pull request adds a new global setting: `ignore_missing_images:`. It does what it says-- allows the site build to continue even if all your images aren't there. 

This setting can accept a boolean value, a jekyll environment name, or an array of jekyll environment names.