### PR TITLE
Data sizes

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -6,7 +6,7 @@
 This is a listing of the various text arrangements that JPT can give you. Select one by setting
 `markup:` in the relevant [markup preset]({{ site.baseurl }}/presets).
 
-Example: 
+Example:
 
 ```yml
 # /_data/picture.yml
@@ -18,35 +18,46 @@ markup_presets:
 
 ## Standard HTML:
 
-* **`picture`:** `<picture>` element surrounding a `<source>` tag for each required srcset, and a
+- **`picture`:** `<picture>` element surrounding a `<source>` tag for each required srcset, and a
   fallback `<img>`.
 
-* **`img`:** output a single `<img>` tag with a `srcset` entry.
+- **`img`:** output a single `<img>` tag with a `srcset` entry.
 
-* **`auto`:** Supply an img tag when you have only one srcset, otherwise supply a picture tag.
+- **`auto`:** Supply an img tag when you have only one srcset, otherwise supply a picture tag.
 
 ## Javascript Friendly:
 
-* **`data_picture`, `data_img`, `data_auto`:** Analogous to their counterparts, but instead of
-`src`, `srcset`, and `sizes`, you get `data-src`, `data-srcset`, and `data-sizes`. This allows you
-to use javascript for things like [lazy loading](https://github.com/verlok/lazyload). Include a
-basic `img` fallback within a `<noscript>` tag by setting `noscript: true` in the preset. This
-allows you to keep working images for your non-javascript-enabled users.
+- **`data_picture`, `data_img`, `data_auto`:** Analogous to their counterparts above, but instead of
+  `src`, `srcset`, and `sizes`, you get `data-src`, `data-srcset`, and `data-sizes`. This allows you
+  to use javascript for things like [lazy loading](https://github.com/verlok/lazyload).
 
-  *Example:* 
+#### Special Options
 
-  ```yml
-  # /_data/picture.yml
-  markup_presets:
-    lazy: 
-      markup: data_auto
-      noscript: true
-  ```
+The following preset configuration settings only apply to the `data_` output formats.
+
+- **noscript**
+
+  _Format:_ `noscript: true|false`
+
+  _Default:_ `false`
+
+  Include a basic `img` fallback within a `<noscript>` tag, giving your javascript-disabled users
+  something to look at.
+
+- **data_sizes**
+
+  _Format:_ `data_sizes: true|false`
+
+  _Default:_ `true`
+
+  This option sets whether you would like JPT's auto-generated sizes to be returned as a
+  `data-sizes` attribute or a normal `sizes` attribute. (Useful for interfacing nicely with all the
+  various JS image libraries out there.)
 
 ## Fragments:
 
-* `direct_url`: Generates an image and returns only its url. Uses `fallback_` properties (width
-and format).
+- **`direct_url`**: Generates an image and returns only its url. Uses `fallback_` properties (width
+  and format).
 
-* `naked_srcset`: Builds a srcset and nothing else (not even the surrounding quotes). Note that the
-(image) `format` setting must still be an array, even if you only give it one value.
+- **`naked_srcset`**: Builds a srcset and nothing else (not even the surrounding quotes). Note that the
+  (image) `format` setting must still be an array, even if you only give it one value.

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -9,6 +9,9 @@ this file, and probably the `_data/` directory as well.
 
 Here's an [example data file]({{ site.baseurl }}/example_presets).
 
+Any settings which are specific to particular output formats are documented on the [output
+formats]({{site.baseurl}}/output) page.
+
 ## Required Knowledge
 
 If you don't know the difference between resolution switching and art direction, stop now and read

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,6 +2,8 @@
 ---
 # Release History
 
+* 1.8.0 Nov 25, 2019
+  * Add `data_sizes` setting for the `data_` family of output formats.
 * 1.7.1 Nov 14, 2019
   * Fix some HTML attribute related bugs
   * Add a few items to the FAQ

--- a/lib/jekyll_picture_tag/defaults/presets.yml
+++ b/lib/jekyll_picture_tag/defaults/presets.yml
@@ -6,3 +6,4 @@ fallback_format: original
 noscript: false
 link_source: false
 quality: 75
+data_sizes: true

--- a/lib/jekyll_picture_tag/output_formats/data_attributes.rb
+++ b/lib/jekyll_picture_tag/output_formats/data_attributes.rb
@@ -18,7 +18,10 @@ module PictureTag
       end
 
       def add_sizes(element, srcset)
-        element.attributes << { 'data-sizes' => srcset.sizes } if srcset.sizes
+        return unless srcset.sizes
+
+        attribute = PictureTag.preset['data_sizes'] ? 'data-sizes' : 'sizes'
+        element.attributes << { attribute => srcset.sizes }
       end
 
       def build_noscript(base_content)

--- a/lib/jekyll_picture_tag/version.rb
+++ b/lib/jekyll_picture_tag/version.rb
@@ -1,3 +1,3 @@
 module PictureTag
-  VERSION = '1.7.1'.freeze
+  VERSION = '1.8.0'.freeze
 end

--- a/test/integration/test_presets.rb
+++ b/test/integration/test_presets.rb
@@ -65,15 +65,34 @@ class TestIntegrationPresets < Minitest::Test
     assert_equal '(max-width: 600px) 80vw, 50%', output.at_css('img')['sizes']
   end
 
-  # pixel ratio sourceset
+  # Pixel ratio srcset
   def test_pixel_ratio
     output = tested 'pixel_ratio rms.jpg'
-    assert errors_ok? output
 
     correct = '/generated/rms-10-46a48b.jpg 1.0x,'\
       ' /generated/rms-20-46a48b.jpg 2.0x, /generated/rms-30-46a48b.jpg 3.0x'
 
     assert_equal correct, output.at_css('img')['srcset']
+  end
+
+  # data_ output with sizes attr, yes data-sizes
+  def test_data_img_yes_size
+    output = tested('data_img_yes_size rms.jpg')
+
+    assert errors_ok? output
+
+    assert_equal '(max-width: 600px) 80vw, 50%',
+                 output.at_css('img')['data-sizes']
+  end
+
+  # data_ output with sizes attr, no data-sizes
+  def test_data_img_no_size
+    output = tested('data_img_no_size rms.jpg')
+
+    assert errors_ok? output
+
+    assert_equal '(max-width: 600px) 80vw, 50%',
+                 output.at_css('img')['sizes']
   end
 
   # attributes from preset

--- a/test/stubs/jekyll.rb
+++ b/test/stubs/jekyll.rb
@@ -82,6 +82,26 @@ module JekyllStub
           'formats' => %w[webp original]
         },
 
+        'data_img_no_size' => {
+          'markup' => 'picture',
+          'widths' => @widths,
+          'sizes' => {
+            'mobile' => '80vw'
+          },
+          'size' => '50%',
+          'data_sizes' => false
+        },
+
+        'data_img_yes_size' => {
+          'markup' => 'data_auto',
+          'widths' => @widths,
+          'sizes' => {
+            'mobile' => '80vw'
+          },
+          'size' => '50%',
+          'data_sizes' => true
+        },
+
         'direct_url' => {
           'markup' => 'direct_url',
           'fallback_width' => 100

--- a/test/stubs/jekyll.rb
+++ b/test/stubs/jekyll.rb
@@ -83,7 +83,7 @@ module JekyllStub
         },
 
         'data_img_no_size' => {
-          'markup' => 'picture',
+          'markup' => 'data_img',
           'widths' => @widths,
           'sizes' => {
             'mobile' => '80vw'
@@ -93,7 +93,7 @@ module JekyllStub
         },
 
         'data_img_yes_size' => {
-          'markup' => 'data_auto',
+          'markup' => 'data_img',
           'widths' => @widths,
           'sizes' => {
             'mobile' => '80vw'

--- a/test/unit/output_formats/test_helper_output.rb
+++ b/test/unit/output_formats/test_helper_output.rb
@@ -38,7 +38,8 @@ module OutputFormatTestHelper
   def stub_picture_tag
     PictureTag.stubs(fallback_format: 'fallback format',
                      fallback_width: 100,
-                     preset: { 'widths' => [100, 200, 300] },
+                     preset: { 'widths' => [100, 200, 300],
+                               'data_sizes' => true },
                      html_attributes: {},
                      nomarkdown?: false)
   end


### PR DESCRIPTION


Add new feature, as requested. 

@jessecrouch - You'll need to set `data_sizes: false` in the relevant preset, and that should give you a plain `sizes` attribute instead of `data-sizes`. Let me know if it gives you any trouble!

close #155 