### PR TITLE
Off switch

### DIFF
--- a/docs/global_configuration.md
+++ b/docs/global_configuration.md
@@ -111,10 +111,31 @@ picture:
 
   *Example:* `nomarkdown: false`
 
-  *Default*: `true`
+  *Default:* `true`
 
   Whether or not to surround j-p-t's output with a `{::nomarkdown}..{:/nomarkdown}` block when called
   from within a markdown file. 
 
   This setting is overridden by the same setting in a preset. See [the notes]({{ site.baseurl
   }}/notes) for more detailed information. 
+
+* **Disable Jekyll Picture Tag**
+
+  *Format:* `disabled: (true|false|environment|array of environments)`
+
+  *Examples:* 
+
+    - `disabled: true`
+
+    - `disabled: development`
+
+    - `disabled: [development, staging]`
+
+  *Default:* `false`
+
+  Disable image generation entirely and leave a generic placeholder instead. Useful for debugging,
+  or to speed up site builds when you're working on something else.
+
+  Hint: If you're going to toggle this on and off frequently, you might just use an environment
+  variable. Set this to something like `nopics`, and then start the Jekyll server with something
+  like `JEKYLL_ENV=nopics bundle exec jekyll serve` when you don't want image generation.

--- a/lib/jekyll_picture_tag.rb
+++ b/lib/jekyll_picture_tag.rb
@@ -50,19 +50,43 @@ module PictureTag
     end
 
     def render(context)
-      # Jekyll passes in a mostly undocumented context object, which appears to
-      # hold the entire site, including configuration and the _data dir.
+      setup(context)
+
+      if PictureTag.disabled?
+        placeholder
+      else
+        PictureTag.output_class.new.to_s
+      end
+    end
+
+    private
+
+    def setup(context)
       PictureTag.context = context
 
-      # The instruction set depends on both the context and the tag parameters:
+      # Now that we have both the tag parameters and the context object, we can
+      # build our instruction set.
       PictureTag.instructions = Instructions::Set.new(@raw_params)
 
       # We need to explicitly prevent jekyll from overwriting our generated
-      # files:
+      # image files:
       Utils.keep_files
+    end
 
-      # Return a string:
-      PictureTag.output_class.new.to_s
+    def placeholder
+      <<~HEREDOC
+        <div>
+          <h3>
+            JPT Image Placeholder
+          </h3>
+
+          <p>
+            Jekyll Picture Tag is disabled for this build environment. See the
+            <a href="https://rbuchberger.github.io/jekyll_picture_tag/global_configuration">
+            relevant docs</a> for more information.
+          </p>
+        </div>
+      HEREDOC
     end
   end
 end

--- a/lib/jekyll_picture_tag.rb
+++ b/lib/jekyll_picture_tag.rb
@@ -84,7 +84,7 @@ module PictureTag
 
     def placeholder
       <<~HEREDOC
-        <div>
+        <div style="border: 1px solid red; padding: 10px;">
           <h3>
             JPT Image Placeholder
           </h3>

--- a/lib/jekyll_picture_tag.rb
+++ b/lib/jekyll_picture_tag.rb
@@ -18,9 +18,9 @@ require_relative 'jekyll_picture_tag/router'
 #
 # Description: Easy responsive images for Jekyll.
 #
-# Download: https://github.com/rbuchberger/jekyll_picture_tag
-# Documentation: https://github.com/rbuchberger/jekyll_picture_tag/readme.md
-# Issues: https://github.com/rbuchberger/jekyll_picture_tag/issues
+# Download: https://rubygems.org/gems/jekyll_picture_tag
+# Documentation: https://rbuchberger.github.io/jekyll_picture_tag/
+# Issues: https://github.com/rbuchberger/jekyll_picture_tag/
 #
 # Syntax:
 # {% picture [preset] img.jpg [media_query: alt-img.jpg] [attributes] %}
@@ -39,16 +39,25 @@ require_relative 'jekyll_picture_tag/router'
 #
 # See the documentation for full configuration and usage instructions.
 module PictureTag
+  # The router module is important. If you're looking for the actual code which
+  # handles a `PictureTag.(some method)`, start there.
   extend Router
+
   ROOT_PATH = __dir__
 
   # This is the actual liquid tag, which provides the interface with Jekyll.
   class Picture < Liquid::Tag
+    # First jekyll initializes our class with a few arguments, of which we only
+    # care about the params (arguments passed to the liquid tag). Jekyll makes
+    # no attempt to parse them; they're given as a string.
     def initialize(tag_name, raw_params, tokens)
       @raw_params = raw_params
       super
     end
 
+    # Then jekyll calls the 'render' method and passes it a mostly undocumented
+    # context object, which appears to hold the entire site including its
+    # configuration and the parsed _data dir.
     def render(context)
       setup(context)
 

--- a/lib/jekyll_picture_tag/defaults/global.yml
+++ b/lib/jekyll_picture_tag/defaults/global.yml
@@ -7,3 +7,4 @@ picture:
   cdn_environments: ['production']
   nomarkdown: true
   ignore_missing_images: false
+  disabled: false

--- a/lib/jekyll_picture_tag/instructions/configuration.rb
+++ b/lib/jekyll_picture_tag/instructions/configuration.rb
@@ -38,16 +38,14 @@ module PictureTag
       end
 
       def continue_on_missing?
-        setting = pconfig['ignore_missing_images']
-
-        # Config setting can be a string, an array, or a boolean
-        if setting.is_a? Array
-          setting.include? jekyll_env
-        elsif setting.is_a? String
-          setting == jekyll_env
-        else
-          setting
-        end
+        env_check pconfig['ignore_missing_images']
+      rescue ArgumentError
+        raise ArgumentError,
+              <<~HEREDOC
+                continue_on_missing setting invalid. Must be either a boolean
+                (true/false), an environment name, or an array of environment
+                names.
+              HEREDOC
       end
 
       def cdn?
@@ -58,6 +56,22 @@ module PictureTag
 
       def content
         @content ||= setting_merge(defaults, PictureTag.site.config)
+      end
+
+      # There are a few config settings which can either be booleans,
+      # environment names, or arrays of environment names. This method works it
+      # out and returns a boolean.
+      def env_check(setting)
+        if setting.is_a? Array
+          setting.include? jekyll_env
+        elsif setting.is_a? String
+          setting == jekyll_env
+        elsif [true, false].include? setting
+          setting
+        else
+          raise ArgumentError,
+                "#{setting} must either be a string, an array, or a boolean."
+        end
       end
 
       def setting_merge(default, jekyll)

--- a/lib/jekyll_picture_tag/instructions/configuration.rb
+++ b/lib/jekyll_picture_tag/instructions/configuration.rb
@@ -52,6 +52,17 @@ module PictureTag
         pconfig['cdn_url'] && pconfig['cdn_environments'].include?(jekyll_env)
       end
 
+      def disabled?
+        env_check pconfig['disabled']
+      rescue ArgumentError
+        raise ArgumentError,
+              <<~HEREDOC
+                "disabled" setting invalid. Must be either a boolean
+                (true/false), an environment name, or an array of environment
+                names.
+              HEREDOC
+      end
+
       private
 
       def content

--- a/lib/jekyll_picture_tag/router.rb
+++ b/lib/jekyll_picture_tag/router.rb
@@ -69,6 +69,10 @@ module PictureTag
       config.pconfig
     end
 
+    def disabled?
+      config.disabled?
+    end
+
     # Preset forwarding
 
     def widths(media)

--- a/test/integration/test_config.rb
+++ b/test/integration/test_config.rb
@@ -150,4 +150,22 @@ class TestIntegrationConfig < Minitest::Test
     assert_equal src, output.at_css('img')['src']
     assert_equal ss, output.at_css('img')['srcset']
   end
+
+  def test_disabled
+    @pconfig['disabled'] = ['development']
+
+    correct = <<~HEREDOC
+      <h3>
+        JPT Image Placeholder
+      </h3>
+
+      <p>
+        Jekyll Picture Tag is disabled for this build environment. See the <a
+        href="https://rbuchberger.github.io/jekyll_picture_tag/global_configuration">relevant
+        docs</a> for more information.
+      </p>
+    HEREDOC
+
+    assert_equal tested_base, correct
+  end
 end

--- a/test/integration/test_config.rb
+++ b/test/integration/test_config.rb
@@ -154,20 +154,6 @@ class TestIntegrationConfig < Minitest::Test
   def test_disabled
     @pconfig['disabled'] = ['development']
 
-    correct = <<~HEREDOC
-      <div>
-        <h3>
-          JPT Image Placeholder
-        </h3>
-
-        <p>
-          Jekyll Picture Tag is disabled for this build environment. See the <a
-          href="https://rbuchberger.github.io/jekyll_picture_tag/global_configuration">relevant
-          docs</a> for more information.
-        </p>
-      </div>
-    HEREDOC
-
-    assert_equal tested_base, correct
+    assert_includes tested_base, 'Placeholder'
   end
 end

--- a/test/integration/test_config.rb
+++ b/test/integration/test_config.rb
@@ -155,15 +155,17 @@ class TestIntegrationConfig < Minitest::Test
     @pconfig['disabled'] = ['development']
 
     correct = <<~HEREDOC
-      <h3>
-        JPT Image Placeholder
-      </h3>
+      <div>
+        <h3>
+          JPT Image Placeholder
+        </h3>
 
-      <p>
-        Jekyll Picture Tag is disabled for this build environment. See the <a
-        href="https://rbuchberger.github.io/jekyll_picture_tag/global_configuration">relevant
-        docs</a> for more information.
-      </p>
+        <p>
+          Jekyll Picture Tag is disabled for this build environment. See the <a
+          href="https://rbuchberger.github.io/jekyll_picture_tag/global_configuration">relevant
+          docs</a> for more information.
+        </p>
+      </div>
     HEREDOC
 
     assert_equal tested_base, correct

--- a/test/unit/instructions/test_config.rb
+++ b/test/unit/instructions/test_config.rb
@@ -70,6 +70,14 @@ class ConfigTest < Minitest::Test
     refute tested.continue_on_missing?
   end
 
+  def test_continue_bad_arg
+    @pconfig['ignore_missing_images'] = 42
+
+    assert_raises ArgumentError do
+      tested.continue_on_missing?
+    end
+  end
+
   def test_cdn
     @pconfig['cdn_url'] = 'some cdn'
     @pconfig['cdn_environments'] = %w[development production]

--- a/test/unit/instructions/test_config.rb
+++ b/test/unit/instructions/test_config.rb
@@ -107,4 +107,12 @@ class ConfigTest < Minitest::Test
 
     refute tested.disabled?
   end
+
+  def test_disabled_bad_arg
+    @pconfig['disabled'] = 42
+
+    assert_raises ArgumentError do
+      tested.disabled?
+    end
+  end
 end

--- a/test/unit/instructions/test_config.rb
+++ b/test/unit/instructions/test_config.rb
@@ -89,4 +89,22 @@ class ConfigTest < Minitest::Test
 
     refute tested.cdn?
   end
+
+  def test_disabled_bool
+    @pconfig['disabled'] = true
+
+    assert tested.disabled?
+  end
+
+  def test_disabled_string
+    @pconfig['disabled'] = 'development'
+
+    assert tested.disabled?
+  end
+
+  def test_disabled_array
+    @pconfig['disabled'] = ['production']
+
+    refute tested.disabled?
+  end
 end


### PR DESCRIPTION
re #161 

These changes add a setting which disables JPT and leaves a placeholder instead, for debugging purposes or to speed up build times when you're not working with images. 

I'm not going to close the issue, because I'd also like to add a 'fast build' option as a middle ground between checking every single image, and returning no images at all. More on that later. 