### PR TITLE
173 height

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,6 @@
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+AllCops:
+  NewCops: enable
+  

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -295,7 +295,37 @@ width (thumbnails and icons). To use a multiplier-based srcset, set `pixel_ratio
   If you don't give a setting for a particular format it'll fall back to the `quality` setting
   above, and if you don't set _that_ it'll default to 75.
 
-* **HTML Attributes**
+* **Width & Height attributes (Anti-Loading-Jank)**
+
+  _Format:_
+
+  ```yml
+  dimension_attributes: true | false
+  ```
+
+  _Example:_
+
+  ```yml
+  dimension_attributes: true
+  ```
+
+  _Default:_ `false`
+
+  Prevent page reflow (aka jank) while images are loading, by adding `width` and `height` attributes
+  to the `<img>` tag in the correct aspect ratio.
+
+  For an explanation of why and how you want to do this, [here](https://youtu.be/4-d_SoCHeWE) is a
+  great explanation.
+
+  Caveats: 
+    * You need `width: 100%;` and `height: auto;` (or vice versa) set in CSS on the `<img>`
+      tags, or they will be stretched weirdly.
+    * This works on `<img>` tags and `<picture>` tags when offering images in multiple widths and
+      formats, but it does not work if you are using art direction (in other words, if you have
+      multiple source images). This is because these attributes can only be applied to the `<img>`
+      tag, of which there is exactly one.
+
+* **Arbitrary HTML Attributes**
 
   _Format:_
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,6 +1,11 @@
 ---
 ---
 # Release History
+* 1.11.0 July 27, 2020
+  * **Width and height attribute support!** Begone, page reflow.
+  * Cache image information between builds
+  * Change image naming format. This update will trigger all images to be regenerated, so you may
+    want to delete your generated images folder beforehand.
 * 1.10.2 July 6, 2020
   * Bugfix for fallback image files not actually getting generated
 * 1.10.1 July 2, 2020

--- a/jekyll_picture_tag.gemspec
+++ b/jekyll_picture_tag.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'solargraph'
 
   spec.add_dependency 'addressable', '~> 2.6'
-  spec.add_dependency 'base32', '~> 0.3'
   spec.add_dependency 'mime-types', '~> 3'
   spec.add_dependency 'mini_magick', '~> 4'
   spec.add_dependency 'objective_elements', '~> 1.1.2'

--- a/lib/jekyll_picture_tag.rb
+++ b/lib/jekyll_picture_tag.rb
@@ -9,6 +9,7 @@ require_relative 'jekyll_picture_tag/srcsets'
 require_relative 'jekyll_picture_tag/utils'
 require_relative 'jekyll_picture_tag/img_uri'
 require_relative 'jekyll_picture_tag/router'
+require_relative 'jekyll_picture_tag/cache'
 
 # Title: Jekyll Picture Tag
 # Authors: Rob Wierzbowski   : @robwierzbowski

--- a/lib/jekyll_picture_tag/cache.rb
+++ b/lib/jekyll_picture_tag/cache.rb
@@ -1,1 +1,2 @@
 require_relative 'cache/base.rb'
+require_relative 'cache/source.rb'

--- a/lib/jekyll_picture_tag/cache.rb
+++ b/lib/jekyll_picture_tag/cache.rb
@@ -1,0 +1,1 @@
+require_relative 'cache/base.rb'

--- a/lib/jekyll_picture_tag/cache.rb
+++ b/lib/jekyll_picture_tag/cache.rb
@@ -1,2 +1,3 @@
 require_relative 'cache/base.rb'
 require_relative 'cache/source.rb'
+require_relative 'cache/generated.rb'

--- a/lib/jekyll_picture_tag/cache.rb
+++ b/lib/jekyll_picture_tag/cache.rb
@@ -1,3 +1,3 @@
-require_relative 'cache/base.rb'
-require_relative 'cache/source.rb'
-require_relative 'cache/generated.rb'
+require_relative 'cache/base'
+require_relative 'cache/source'
+require_relative 'cache/generated'

--- a/lib/jekyll_picture_tag/cache/base.rb
+++ b/lib/jekyll_picture_tag/cache/base.rb
@@ -38,23 +38,12 @@ module PictureTag
       end
 
       def directory
-        File.join PictureTag.site.cache_dir,
-                  'jpt',
-                  cache_dir
+        File.join(PictureTag.site.cache_dir, 'jpt', cache_dir)
       end
 
       # /home/dave/my_blog/.jekyll-cache/jpt/somefolder/myimage.jpg.json
       def filename
-        File.join directory,
-                  @base_name + '.json'
-      end
-
-      def cache_dir
-        ''
-      end
-
-      def template
-        {}
+        File.join(directory, @base_name + '.json')
       end
     end
   end

--- a/lib/jekyll_picture_tag/cache/base.rb
+++ b/lib/jekyll_picture_tag/cache/base.rb
@@ -1,0 +1,61 @@
+require 'json'
+
+module PictureTag
+  module Cache
+    # Basic image information cache functionality
+    module Base
+      def initialize(base_name)
+        @base_name = base_name
+      end
+
+      def [](key)
+        data[key]
+      end
+
+      def []=(key, value)
+        raise ArgumentError unless template.keys.include? key
+
+        data[key] = value
+      end
+
+      # Call after updating data.
+      def write
+        FileUtils.mkdir_p directory
+
+        File.open(filename, 'w') do |f|
+          f.write JSON.generate(data)
+        end
+      end
+
+      private
+
+      def data
+        @data ||= if File.exist?(filename)
+                    JSON.parse(File.read(filename))
+                  else
+                    template
+                  end
+      end
+
+      def directory
+        File.join PictureTag.site.cache_dir,
+                  'jpt',
+                  cache_dir
+      end
+
+      # /home/dave/my_blog/.jekyll-cache/jpt/somefolder/myimage.jpg.json
+      def filename
+        File.join directory,
+                  @base_name + '.json'
+      end
+
+      def cache_dir
+        ''
+      end
+
+      def template
+        {}
+      end
+    end
+  end
+end

--- a/lib/jekyll_picture_tag/cache/base.rb
+++ b/lib/jekyll_picture_tag/cache/base.rb
@@ -31,7 +31,7 @@ module PictureTag
 
       def data
         @data ||= if File.exist?(filename)
-                    JSON.parse(File.read(filename))
+                    JSON.parse(File.read(filename)).transform_keys(&:to_sym)
                   else
                     template
                   end

--- a/lib/jekyll_picture_tag/cache/base.rb
+++ b/lib/jekyll_picture_tag/cache/base.rb
@@ -49,12 +49,6 @@ module PictureTag
         File.dirname(@base_name)
       end
 
-      # /home/dave/my_blog/.jekyll-cache/jpt/(cache_dir)/assets/myimage.jpg.json
-      # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      def directory
-        File.join(base_directory, sub_directory)
-      end
-
       # /home/dave/my_blog/.jekyll-cache/jpt/somefolder/myimage.jpg.json
       # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       def filename

--- a/lib/jekyll_picture_tag/cache/base.rb
+++ b/lib/jekyll_picture_tag/cache/base.rb
@@ -20,9 +20,9 @@ module PictureTag
 
       # Call after updating data.
       def write
-        FileUtils.mkdir_p directory
+        FileUtils.mkdir_p(File.join(base_directory, sub_directory))
 
-        File.open(filename, 'w') do |f|
+        File.open(filename, 'w+') do |f|
           f.write JSON.generate(data)
         end
       end
@@ -37,13 +37,28 @@ module PictureTag
                   end
       end
 
-      def directory
+      # /home/dave/my_blog/.jekyll-cache/jpt/(cache_dir)/assets/myimage.jpg.json
+      # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      def base_directory
         File.join(PictureTag.site.cache_dir, 'jpt', cache_dir)
       end
 
+      # /home/dave/my_blog/.jekyll-cache/jpt/(cache_dir)/assets/myimage.jpg.json
+      #                                                 ^^^^^^^^
+      def sub_directory
+        File.dirname(@base_name)
+      end
+
+      # /home/dave/my_blog/.jekyll-cache/jpt/(cache_dir)/assets/myimage.jpg.json
+      # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      def directory
+        File.join(base_directory, sub_directory)
+      end
+
       # /home/dave/my_blog/.jekyll-cache/jpt/somefolder/myimage.jpg.json
+      # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       def filename
-        File.join(directory, @base_name + '.json')
+        File.join(base_directory, @base_name + '.json')
       end
     end
   end

--- a/lib/jekyll_picture_tag/cache/generated.rb
+++ b/lib/jekyll_picture_tag/cache/generated.rb
@@ -1,0 +1,20 @@
+module PictureTag
+  module Cache
+    # Caches generated image details, so we can skip expensive operations whenever
+    # possible.
+    # Stored width and height are values for the source image, after cropping.
+    class Generated
+      include Base
+
+      private
+
+      def cache_dir
+        'generated'
+      end
+
+      def template
+        { width: nil, height: nil }
+      end
+    end
+  end
+end

--- a/lib/jekyll_picture_tag/cache/source.rb
+++ b/lib/jekyll_picture_tag/cache/source.rb
@@ -1,0 +1,19 @@
+module PictureTag
+  module Cache
+    # Caches source image details, so we can skip expensive operations whenever
+    # possible.
+    class Source
+      include Base
+
+      private
+
+      def template
+        { digest: nil, width: nil, height: nil }
+      end
+
+      def cache_dir
+        'source'
+      end
+    end
+  end
+end

--- a/lib/jekyll_picture_tag/defaults/presets.yml
+++ b/lib/jekyll_picture_tag/defaults/presets.yml
@@ -8,3 +8,4 @@ link_source: false
 quality: 75
 data_sizes: true
 gravity: center
+dimension_attributes: false

--- a/lib/jekyll_picture_tag/generated_image.rb
+++ b/lib/jekyll_picture_tag/generated_image.rb
@@ -1,5 +1,4 @@
 require 'mini_magick'
-require 'base32'
 
 module PictureTag
   # Represents a generated image file.
@@ -32,7 +31,7 @@ module PictureTag
     # /home/dave/my_blog/_site/generated/somefolder/myimage-100-123abc.jpg
     #                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     def name
-      name_left + digest + name_right
+      @name ||= "#{@source.base_name}-#{@width}-#{id}.#{@format}"
     end
 
     # https://example.com/assets/images/myimage-100-123abc.jpg
@@ -41,56 +40,47 @@ module PictureTag
       ImgURI.new(name).to_s
     end
 
-    def cropped_source_width
-      image.width
+    # Post crop
+    def source_width
+      update_cache unless cache[:width]
+
+      cache[:width]
+    end
+
+    # Post crop
+    def source_height
+      update_cache unless cache[:height]
+
+      cache[:height]
     end
 
     private
 
-    # /home/dave/my_blog/_site/generated/somefolder/myimage-100-123abc.jpg
-    #                                    ^^^^^^^^^^^^^^^^^^^^^^^
-    def name_left
-      "#{@source.base_name}-#{@width}-"
+    # We exclude width and format from the cache name, since it isn't specific to them.
+    def cache
+      @cache ||= Cache::Generated.new("#{@source.base_name}-#{id}")
     end
 
-    # /home/dave/my_blog/_site/generated/somefolder/myimage-100-123abc.jpg
-    #                                                           ^^^^^^
-    def digest
-      guess_digest if !@source.digest_guess && PictureTag.fast_build?
+    def update_cache
+      return if @source.missing
 
-      @source.digest
+      # Ensure it's generated:
+      image
+
+      cache[:width] = @source_dimensions[:width]
+      cache[:height] = @source_dimensions[:height]
+
+      cache.write
     end
 
-    # /home/dave/my_blog/_site/generated/somefolder/myimage-100-123abc.jpg
-    #                                                                 ^^^^
-    def name_right
-      crop_code + '.' + @format
+    # Hash all inputs and truncate, so we know when they change without getting too long.
+    # /home/dave/my_blog/_site/generated/somefolder/myimage-100-1234abcde.jpg
+    #                                                           ^^^^^^^^^
+    def id
+      @id ||= Digest::MD5.hexdigest([@source.digest, @crop, @gravity, quality].join)[0..8]
     end
 
-    # Hash the crop settings, so we can detect when they change.  We use a
-    # base32 encoding scheme to pack more information into fewer characters,
-    # without dealing with various filesystem naming limitations that would crop
-    # up using base64 (such as NTFS being case insensitive).
-    def crop_code
-      return '' unless @crop
-
-      Base32.encode(
-        Digest::MD5.hexdigest(@crop + @gravity)
-      )[0..2]
-    end
-
-
-
-    def dest_glob
-
-    end
-
-    def generate_image
-      puts 'Generating new image file: ' + name
-      process_image
-      write_image
-    end
-
+    # Post crop, before resizing and reformatting
     def image
       @image ||= open_image
     end
@@ -105,7 +95,19 @@ module PictureTag
         end
       end
 
+      @source_dimensions = { width: image_base.width, height: image_base.height }
+
       image_base
+    end
+
+    def generate_image
+      puts 'Generating new image file: ' + name
+      process_image
+      write_image
+    end
+
+    def quality
+      PictureTag.quality(@format)
     end
 
     def process_image
@@ -115,7 +117,7 @@ module PictureTag
       end
 
       image.format @format
-      image.quality PictureTag.quality(@format)
+      image.quality quality
     end
 
     def write_image

--- a/lib/jekyll_picture_tag/generated_image.rb
+++ b/lib/jekyll_picture_tag/generated_image.rb
@@ -79,29 +79,10 @@ module PictureTag
       )[0..2]
     end
 
-    # Used for the fast build option: look for a file which matches everything
-    # we know about the destination file without calculating a digest on the
-    # source file, and if it exists we assume it's the right one.
-    def guess_digest
-      matches = dest_glob
-      return unless matches.length == 1
 
-      # Start and finish of the destination image's hash value
-      finish = -name_right.length
-      start = finish - 6
 
-      # The source image keeps track of this guess, so we hand it off:
-      @source.digest_guess = matches.first[start...finish]
-    end
-
-    # Returns a list of images which are probably correct.
     def dest_glob
-      query = File.join(
-        PictureTag.dest_dir,
-        name_left + '?' * 6 + name_right
-      )
 
-      Dir.glob query
     end
 
     def generate_image

--- a/lib/jekyll_picture_tag/generated_image.rb
+++ b/lib/jekyll_picture_tag/generated_image.rb
@@ -4,6 +4,7 @@ module PictureTag
   # Represents a generated image file.
   class GeneratedImage
     attr_reader :width, :format
+
     include MiniMagick
 
     def initialize(source_file:, width:, format:, crop: nil, gravity: '')

--- a/lib/jekyll_picture_tag/generated_image.rb
+++ b/lib/jekyll_picture_tag/generated_image.rb
@@ -119,16 +119,11 @@ module PictureTag
     end
 
     def write_image
-      # Make sure destination directory exists:
-      FileUtils.mkdir_p(dest_dir) unless Dir.exist?(dest_dir)
+      FileUtils.mkdir_p(File.dirname(absolute_filename))
 
       image.write absolute_filename
 
       FileUtils.chmod(0o644, absolute_filename)
-    end
-
-    def dest_dir
-      File.dirname absolute_filename
     end
 
     def process_format(format)

--- a/lib/jekyll_picture_tag/img_uri.rb
+++ b/lib/jekyll_picture_tag/img_uri.rb
@@ -8,6 +8,7 @@ module PictureTag
   # image. Call to_s on it to get the link.
   class ImgURI
     attr_reader :filename, :source_image
+
     def initialize(filename, source_image: false)
       @source_image = source_image
       @filename = filename

--- a/lib/jekyll_picture_tag/instructions/arg_splitter.rb
+++ b/lib/jekyll_picture_tag/instructions/arg_splitter.rb
@@ -51,9 +51,10 @@ module PictureTag
       end
 
       def handle_special(char)
-        if char == '\\'
+        case char
+        when '\\'
           @escaped = true
-        elsif char == '"'
+        when '"'
           @in_quotes = !@in_quotes
           @word << char
         end

--- a/lib/jekyll_picture_tag/instructions/preset.rb
+++ b/lib/jekyll_picture_tag/instructions/preset.rb
@@ -3,6 +3,7 @@ module PictureTag
     # Handles the specific tag image set to construct.
     class Preset
       attr_reader :name
+
       def initialize(name)
         @name = name
         @content = build_preset

--- a/lib/jekyll_picture_tag/output_formats/basic.rb
+++ b/lib/jekyll_picture_tag/output_formats/basic.rb
@@ -6,6 +6,10 @@ module PictureTag
     class Basic
       include ObjectiveElements
 
+      def to_s
+        wrap(base_markup).to_s
+      end
+
       # Used for both the fallback image, and for the complete markup.
       def build_base_img
         img = SingleTag.new 'img'
@@ -21,10 +25,6 @@ module PictureTag
         add_alt(img, attributes['alt'])
 
         img
-      end
-
-      def to_s
-        wrap(base_markup).to_s
       end
 
       private
@@ -86,6 +86,8 @@ module PictureTag
         image
       end
 
+      # It's only a candidate, because we don't know if the fallback width
+      # setting is larger than the source file.
       def fallback_candidate
         @fallback_candidate ||= GeneratedImage.new(
           source_file: PictureTag.source_images.first,

--- a/lib/jekyll_picture_tag/output_formats/basic.rb
+++ b/lib/jekyll_picture_tag/output_formats/basic.rb
@@ -119,7 +119,7 @@ module PictureTag
 
       def source_width
         if PictureTag.crop
-          fallback_candidate.cropped_source_width
+          fallback_candidate.source_width
         else
           source.width
         end

--- a/lib/jekyll_picture_tag/output_formats/img.rb
+++ b/lib/jekyll_picture_tag/output_formats/img.rb
@@ -16,9 +16,10 @@ module PictureTag
 
         add_srcset(img, srcset)
         add_sizes(img, srcset)
-        add_dimensions(img, srcset)
 
         img.attributes << PictureTag.html_attributes['parent']
+
+        add_dimensions(img, srcset)
 
         img
       end
@@ -26,10 +27,8 @@ module PictureTag
       def add_dimensions(img, srcset)
         return unless PictureTag.preset['dimension_attributes']
 
-        img.attributes << {
-          width: srcset.width_attribute,
-          height: srcset.height_attribute
-        }
+        img.width = srcset.width_attribute
+        img.height = srcset.height_attribute
       end
     end
   end

--- a/lib/jekyll_picture_tag/output_formats/img.rb
+++ b/lib/jekyll_picture_tag/output_formats/img.rb
@@ -3,6 +3,8 @@ module PictureTag
     # Represents a bare <img> tag with a srcset attribute.
     # Used when <picture> is unnecessary.
     class Img < Basic
+      private
+
       def srcset
         @srcset ||= build_srcset(
           PictureTag.source_images.first, PictureTag.formats.first

--- a/lib/jekyll_picture_tag/output_formats/img.rb
+++ b/lib/jekyll_picture_tag/output_formats/img.rb
@@ -14,10 +14,20 @@ module PictureTag
 
         add_srcset(img, srcset)
         add_sizes(img, srcset)
+        add_dimensions(img, srcset)
 
         img.attributes << PictureTag.html_attributes['parent']
 
         img
+      end
+
+      def add_dimensions(img, srcset)
+        return unless PictureTag.preset['dimension_attributes']
+
+        img.attributes << {
+          width: srcset.width_attribute,
+          height: srcset.height_attribute
+        }
       end
     end
   end

--- a/lib/jekyll_picture_tag/output_formats/picture.rb
+++ b/lib/jekyll_picture_tag/output_formats/picture.rb
@@ -4,6 +4,10 @@ module PictureTag
     # <img> tag.
     class Picture < Basic
       def srcsets
+        @srcsets ||= build_srcsets
+      end
+
+      def build_srcsets
         formats = PictureTag.formats
         # Source images are provided in reverse order and must be flipped:
         images = PictureTag.source_images.reverse
@@ -35,6 +39,22 @@ module PictureTag
         source.type = srcset.mime_type
 
         source
+      end
+
+      def build_base_img
+        img = super
+
+        # Only add source dimensions if there is a single source image.
+        # Currently you can't use both art direction and intrinsic image sizes.
+        if PictureTag.preset['dimension_attributes'] &&
+           PictureTag.source_images.length == 1
+          img.attributes << {
+            width: srcsets.first.width_attribute,
+            height: srcsets.first.height_attribute
+          }
+        end
+
+        img
       end
 
       def base_markup

--- a/lib/jekyll_picture_tag/output_formats/picture.rb
+++ b/lib/jekyll_picture_tag/output_formats/picture.rb
@@ -3,6 +3,8 @@ module PictureTag
     # Represents a <picture> tag, enclosing at least 2 <source> tags and an
     # <img> tag.
     class Picture < Basic
+      private
+
       def srcsets
         @srcsets ||= build_srcsets
       end

--- a/lib/jekyll_picture_tag/router.rb
+++ b/lib/jekyll_picture_tag/router.rb
@@ -9,6 +9,7 @@ module PictureTag
   # gets big, I'll refactor.
   module Router
     attr_accessor :instructions, :context
+
     # Context forwarding
 
     # Global site data

--- a/lib/jekyll_picture_tag/source_image.rb
+++ b/lib/jekyll_picture_tag/source_image.rb
@@ -3,12 +3,13 @@ module PictureTag
   # advantage by storing expensive file reads and writes in instance variables,
   # to be reused by many different generated images.
   class SourceImage
-    attr_reader :name, :shortname, :missing, :media_preset
+    attr_reader :shortname, :missing, :media_preset
     include MiniMagick
 
     def initialize(relative_filename, media_preset = nil)
+      # /home/dave/my_blog/assets/images/somefolder/myimage.jpg
+      #                                  ^^^^^^^^^^^^^^^^^^^^^^
       @shortname = relative_filename
-      @name = grab_file relative_filename
       @media_preset = media_preset
     end
 
@@ -26,17 +27,22 @@ module PictureTag
                   else
                     Digest::MD5.hexdigest(File.read(@name))[0..5]
                   end
+    # /home/dave/my_blog/assets/images/somefolder/myimage.jpg
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    def name
+      @name ||= File.join(PictureTag.source_dir, @shortname)
     end
 
-    # Includes path relative to default source folder and the original filename.
+    # /home/dave/my_blog/assets/images/somefolder/myimage.jpg
+    #                                  ^^^^^^^^^^^^^^^^^^
     def base_name
       @shortname.delete_suffix File.extname(@shortname)
     end
 
-    # File exention
+    # /home/dave/my_blog/assets/images/somefolder/myimage.jpg
+    #                                                     ^^^
     def ext
-      # [1..-1] will strip the leading period.
-      @ext ||= File.extname(@name)[1..-1].downcase
+      @ext ||= File.extname(name)[1..-1].downcase
     end
 
     private

--- a/lib/jekyll_picture_tag/source_image.rb
+++ b/lib/jekyll_picture_tag/source_image.rb
@@ -4,6 +4,7 @@ module PictureTag
   # to be reused by many different generated images.
   class SourceImage
     attr_reader :shortname, :missing, :media_preset
+
     include MiniMagick
 
     def initialize(relative_filename, media_preset = nil)

--- a/lib/jekyll_picture_tag/source_image.rb
+++ b/lib/jekyll_picture_tag/source_image.rb
@@ -27,6 +27,7 @@ module PictureTag
     def height
       @height ||= cache[:height] || 999_999
     end
+
     # /home/dave/my_blog/assets/images/somefolder/myimage.jpg
     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     def name
@@ -71,11 +72,6 @@ module PictureTag
       update_cache if source_digest != cache[:digest]
     end
 
-    def missing_image_warning(source_name)
-      <<~HEREDOC
-        Could not find #{source_name}. Your site will have broken images in it.
-        Continuing.
-      HEREDOC
     def update_cache
       cache[:digest] = source_digest
       cache[:width] = image.width
@@ -84,7 +80,6 @@ module PictureTag
       cache.write
     end
 
-    def missing_image_error(source_name)
     def image
       @image ||= Image.open(name)
     end
@@ -93,11 +88,14 @@ module PictureTag
       @source_digest ||= Digest::MD5.hexdigest(File.read(name))
     end
 
+    def missing_image_warning
+      "JPT Could not find #{name}. Your site will have broken images. Continuing."
+    end
+
+    def missing_image_error
       <<~HEREDOC
-        Jekyll Picture Tag could not find #{source_name}. You can force the
-        build to continue anyway by setting "picture: ignore_missing_images:
-        true" in "_config.yml". This setting can also accept a jekyll build
-        environment, or an array of environments.
+        Could not find #{name}. You can force the build to continue anyway by
+        setting "picture: ignore_missing_images: true" in "_config.yml".
       HEREDOC
     end
   end

--- a/lib/jekyll_picture_tag/source_image.rb
+++ b/lib/jekyll_picture_tag/source_image.rb
@@ -4,7 +4,6 @@ module PictureTag
   # to be reused by many different generated images.
   class SourceImage
     attr_reader :name, :shortname, :missing, :media_preset
-    attr_accessor :digest_guess
     include MiniMagick
 
     def initialize(relative_filename, media_preset = nil)
@@ -24,10 +23,6 @@ module PictureTag
     def digest
       @digest ||= if @missing
                     'x' * 6
-                  elsif PictureTag.fast_build? && @digest_guess
-                    # Digest guess will be handed off to this class by the first
-                    # generated image which needs it (via attr_accessor).
-                    @digest_guess
                   else
                     Digest::MD5.hexdigest(File.read(@name))[0..5]
                   end

--- a/lib/jekyll_picture_tag/source_image.rb
+++ b/lib/jekyll_picture_tag/source_image.rb
@@ -11,6 +11,8 @@ module PictureTag
       #                                  ^^^^^^^^^^^^^^^^^^^^^^
       @shortname = relative_filename
       @media_preset = media_preset
+
+      @missing = missing?
     end
 
     def width
@@ -57,16 +59,19 @@ module PictureTag
 
       if File.exist? source_name
         @missing = false
+    def missing?
+      if File.exist? name
+        false
 
       elsif PictureTag.continue_on_missing?
-        @missing = true
-        Utils.warning missing_image_warning(source_name)
+        Utils.warning(missing_image_warning)
+        true
 
       else
-        raise ArgumentError, missing_image_error(source_name)
+        raise ArgumentError, missing_image_error
       end
+    end
 
-      source_name
     end
 
     def missing_image_warning(source_name)

--- a/lib/jekyll_picture_tag/srcsets/basic.rb
+++ b/lib/jekyll_picture_tag/srcsets/basic.rb
@@ -51,6 +51,14 @@ module PictureTag
         "(#{PictureTag.media_presets[@media]})"
       end
 
+      def width_attribute
+        files.first.source_width.to_s
+      end
+
+      def height_attribute
+        files.first.source_height.to_s
+      end
+
       private
 
       def build_files

--- a/lib/jekyll_picture_tag/srcsets/basic.rb
+++ b/lib/jekyll_picture_tag/srcsets/basic.rb
@@ -23,6 +23,7 @@ module PictureTag
         @format ||= files.first.format
       end
 
+      # GeneratedImage class
       def files
         @files ||= build_files
       end

--- a/lib/jekyll_picture_tag/srcsets/basic.rb
+++ b/lib/jekyll_picture_tag/srcsets/basic.rb
@@ -78,7 +78,7 @@ module PictureTag
 
       def source_width
         @source_width ||= if PictureTag.crop(@media)
-                            target_files.first.cropped_source_width
+                            target_files.first.source_width
                           else
                             @source_image.width
                           end

--- a/lib/jekyll_picture_tag/version.rb
+++ b/lib/jekyll_picture_tag/version.rb
@@ -1,3 +1,3 @@
 module PictureTag
-  VERSION = '1.10.2'.freeze
+  VERSION = '1.11.0'.freeze
 end

--- a/readme.md
+++ b/readme.md
@@ -43,14 +43,15 @@ https://rbuchberger.github.io/jekyll_picture_tag/releases
 
 Latest versions: 
 
-* 1.10.0 May 11, 2020
-  * **Image Cropping support!** access the power of ImageMagick's `crop` function.
-  * Don't issue a warning when `default` preset is not found.
-  * Documentation improvements
 * 1.10.1 July 2, 2020
   * Bugfix for erroneously regenerated images
 * 1.10.2 July 6, 2020
   * Bugfix for fallback image files not actually getting generated
+* 1.11.0 July 27, 2020
+  * **Width and height attribute support!** Begone, page reflow.
+  * Cache image information between builds
+  * Change image naming format. This update will trigger all images to be regenerated, so you may
+    want to delete your generated images folder beforehand.
 
 ## Help Wanted
 

--- a/test/integration/test_config.rb
+++ b/test/integration/test_config.rb
@@ -46,8 +46,8 @@ class TestIntegrationConfig < Minitest::Test
 
     output = tested 'asdf.jpg'
 
-    ss = '/generated/asdf-25-xxxxxx.jpg 25w,' \
-      ' /generated/asdf-50-xxxxxx.jpg 50w, /generated/asdf-100-xxxxxx.jpg 100w'
+    ss = '/generated/asdf-25-e555e4f8b.jpg 25w,' \
+      ' /generated/asdf-50-e555e4f8b.jpg 50w, /generated/asdf-100-e555e4f8b.jpg 100w'
 
     assert_equal ss, output.at_css('img')['srcset']
     assert @stderr.include? 'asdf.jpg'
@@ -59,8 +59,8 @@ class TestIntegrationConfig < Minitest::Test
 
     output = tested 'asdf.jpg'
 
-    ss = '/generated/asdf-25-xxxxxx.jpg 25w,' \
-      ' /generated/asdf-50-xxxxxx.jpg 50w, /generated/asdf-100-xxxxxx.jpg 100w'
+    ss = '/generated/asdf-25-e555e4f8b.jpg 25w,' \
+      ' /generated/asdf-50-e555e4f8b.jpg 50w, /generated/asdf-100-e555e4f8b.jpg 100w'
 
     assert_equal ss, output.at_css('img')['srcset']
     assert @stderr.include? 'asdf.jpg'
@@ -72,8 +72,8 @@ class TestIntegrationConfig < Minitest::Test
 
     output = tested 'asdf.jpg'
 
-    ss = '/generated/asdf-25-xxxxxx.jpg 25w,' \
-      ' /generated/asdf-50-xxxxxx.jpg 50w, /generated/asdf-100-xxxxxx.jpg 100w'
+    ss = '/generated/asdf-25-e555e4f8b.jpg 25w,' \
+      ' /generated/asdf-50-e555e4f8b.jpg 50w, /generated/asdf-100-e555e4f8b.jpg 100w'
 
     assert_equal ss, output.at_css('img')['srcset']
     assert @stderr.include? 'asdf.jpg'
@@ -90,9 +90,9 @@ class TestIntegrationConfig < Minitest::Test
   def test_absolute_urls
     @pconfig['relative_url'] = false
 
-    ss = 'example.com/generated/rms-25-46a48b.jpg 25w,' \
-      ' example.com/generated/rms-50-46a48b.jpg 50w,' \
-      ' example.com/generated/rms-100-46a48b.jpg 100w'
+    ss = 'example.com/generated/rms-25-9ffc043fa.jpg 25w,' \
+      ' example.com/generated/rms-50-9ffc043fa.jpg 50w,' \
+      ' example.com/generated/rms-100-9ffc043fa.jpg 100w'
 
     assert_equal ss, tested.at_css('img')['srcset']
   end
@@ -100,9 +100,9 @@ class TestIntegrationConfig < Minitest::Test
   def test_baseurl
     @jconfig['baseurl'] = 'blog'
 
-    ss = '/blog/generated/rms-25-46a48b.jpg 25w, ' \
-    '/blog/generated/rms-50-46a48b.jpg 50w,' \
-    ' /blog/generated/rms-100-46a48b.jpg 100w'
+    ss = '/blog/generated/rms-25-9ffc043fa.jpg 25w, ' \
+    '/blog/generated/rms-50-9ffc043fa.jpg 50w,' \
+    ' /blog/generated/rms-100-9ffc043fa.jpg 100w'
 
     assert_equal ss, tested.at_css('img')['srcset']
   end
@@ -111,9 +111,9 @@ class TestIntegrationConfig < Minitest::Test
   def test_cdn
     @context.environments = [{ 'jekyll' => { 'environment' => 'production' } }]
     @pconfig['cdn_url'] = 'cdn.net'
-    ss = 'cdn.net/generated/rms-25-46a48b.jpg 25w,' \
-      ' cdn.net/generated/rms-50-46a48b.jpg 50w,' \
-      ' cdn.net/generated/rms-100-46a48b.jpg 100w'
+    ss = 'cdn.net/generated/rms-25-9ffc043fa.jpg 25w,' \
+      ' cdn.net/generated/rms-50-9ffc043fa.jpg 50w,' \
+      ' cdn.net/generated/rms-100-9ffc043fa.jpg 100w'
 
     assert_equal ss, tested.at_css('img')['srcset']
   end
@@ -122,9 +122,9 @@ class TestIntegrationConfig < Minitest::Test
   def test_cdn_env
     @pconfig['cdn_url'] = 'cdn.net'
     @pconfig['cdn_environments'] = ['development']
-    ss = 'cdn.net/generated/rms-25-46a48b.jpg 25w,' \
-      ' cdn.net/generated/rms-50-46a48b.jpg 50w,' \
-      ' cdn.net/generated/rms-100-46a48b.jpg 100w'
+    ss = 'cdn.net/generated/rms-25-9ffc043fa.jpg 25w,' \
+      ' cdn.net/generated/rms-50-9ffc043fa.jpg 50w,' \
+      ' cdn.net/generated/rms-100-9ffc043fa.jpg 100w'
 
     assert_equal ss, tested.at_css('img')['srcset']
   end
@@ -140,8 +140,8 @@ class TestIntegrationConfig < Minitest::Test
   # small source in srcset
   def test_small_source
     output = tested 'too_large rms.jpg'
-    src = '/generated/rms-100-46a48b.jpg'
-    ss = '/generated/rms-100-46a48b.jpg 100w'
+    src = '/generated/rms-100-9ffc043fa.jpg'
+    ss = '/generated/rms-100-9ffc043fa.jpg 100w'
 
     assert @stderr.include? 'rms.jpg'
     assert_equal src, output.at_css('img')['src']
@@ -155,5 +155,6 @@ class TestIntegrationConfig < Minitest::Test
   end
 
   def test_fast_build
+    skip
   end
 end

--- a/test/integration/test_config.rb
+++ b/test/integration/test_config.rb
@@ -155,24 +155,5 @@ class TestIntegrationConfig < Minitest::Test
   end
 
   def test_fast_build
-    File.stubs(:exist?).returns(true)
-    @pconfig['fast_build'] = true
-
-    Digest::MD5.expects(:hexdigest).never
-    Dir.expects(:glob)
-       .with('/tmp/jpt/generated/rms-800-??????.jpg')
-       .returns(['/tmp/jpt/generated/rms-800-46a48b.jpg'])
-
-    output = tested 'rms.jpg'
-    assert_equal std_rms_ss, output.at_css('img')['srcset']
-  end
-
-  # When building images which already exist, source image width should never be
-  # called because it's a huge performance hit.
-  def test_no_width_check
-    File.stubs(:exist?).returns(true)
-    SourceImage.any_instance.expects(:width).never
-
-    tested
   end
 end

--- a/test/integration/test_config.rb
+++ b/test/integration/test_config.rb
@@ -155,6 +155,13 @@ class TestIntegrationConfig < Minitest::Test
   end
 
   def test_fast_build
-    skip
+    File.unstub(:exist?)
+    @pconfig['fast_build'] = true
+
+    tested 'rms.jpg' # Call once to ensure files and caches exist
+
+    PictureTag::SourceImage.any_instance.expects(:source_digest).never
+
+    tested 'rms.jpg'
   end
 end

--- a/test/integration/test_integration_helper.rb
+++ b/test/integration/test_integration_helper.rb
@@ -25,16 +25,16 @@ module TestIntegrationHelper
     output
   end
 
-  def rms_filename(width: 100, format: 'jpg', crop: '')
-    '/tmp/jpt' + rms_url(width: width, format: format, crop: crop)
+  def rms_filename(width: 100, format: 'jpg')
+    '/tmp/jpt' + rms_url(width: width, format: format)
   end
 
-  def rms_url(width: 100, format: 'jpg', crop: '')
-    "/generated/rms-#{width}-46a48b#{crop}.#{format}"
+  def rms_url(width: 100, format: 'jpg')
+    "/generated/rms-#{width}-9ffc043fa.#{format}"
   end
 
-  def spx_url(width: 100, format: 'jpg', crop: '')
-    "/generated/spx-#{width}-2e8bb3#{crop}.#{format}"
+  def spx_url(width: 100, format: 'jpg')
+    "/generated/spx-#{width}-3e829c5a4.#{format}"
   end
 
   def spx_filename(width: 100, format: 'jpg', crop: '')
@@ -42,26 +42,26 @@ module TestIntegrationHelper
   end
 
   def std_spx_ss
-    '/generated/spx-25-2e8bb3.jpg 25w,' \
-       ' /generated/spx-50-2e8bb3.jpg 50w, /generated/spx-100-2e8bb3.jpg 100w'
+    '/generated/spx-25-3e829c5a4.jpg 25w,' \
+       ' /generated/spx-50-3e829c5a4.jpg 50w, /generated/spx-100-3e829c5a4.jpg 100w'
   end
 
   def std_rms_ss
-    '/generated/rms-25-46a48b.jpg 25w,' \
-      ' /generated/rms-50-46a48b.jpg 50w, /generated/rms-100-46a48b.jpg 100w'
+    '/generated/rms-25-9ffc043fa.jpg 25w,' \
+      ' /generated/rms-50-9ffc043fa.jpg 50w, /generated/rms-100-9ffc043fa.jpg 100w'
   end
 
-  def rms_file_array(widths, formats, crop: '')
+  def rms_file_array(widths, formats)
     files = formats.collect do |f|
-      widths.collect { |w| rms_filename(width: w, format: f, crop: crop) }
+      widths.collect { |w| rms_filename(width: w, format: f) }
     end
 
     files.flatten
   end
 
-  def spx_file_array(widths, formats, crop: '')
+  def spx_file_array(widths, formats)
     files = formats.collect do |f|
-      widths.collect { |w| spx_filename(width: w, format: f, crop: crop) }
+      widths.collect { |w| spx_filename(width: w, format: f) }
     end
 
     files.flatten

--- a/test/integration/test_params.rb
+++ b/test/integration/test_params.rb
@@ -60,16 +60,16 @@ class TestIntegrationParams < Minitest::Test
   def test_crop
     output = tested('rms.jpg 10:1 north')
 
-    correct = '/generated/rms-25-46a48bMZS.jpg 25w,'\
-      ' /generated/rms-50-46a48bMZS.jpg 50w,'\
-      ' /generated/rms-100-46a48bMZS.jpg 100w'
+    correct = '/generated/rms-25-8d4abac33.jpg 25w,'\
+      ' /generated/rms-50-8d4abac33.jpg 50w,'\
+      ' /generated/rms-100-8d4abac33.jpg 100w'
 
     assert_equal correct, output.at_css('img')['srcset']
 
     correct_digest =
       '257f0cdf64bc05b1e474265216ec85994d3123e609b812ed75d875610a85455c'
     generated_digest =
-      MiniMagick::Image.open(rms_filename(crop: 'MZS')).signature
+      MiniMagick::Image.open('/tmp/jpt/generated/rms-100-8d4abac33.jpg').signature
 
     assert_equal correct_digest, generated_digest
   end
@@ -77,8 +77,8 @@ class TestIntegrationParams < Minitest::Test
   # Make sure that when cropping images, we don't enlarge widths
   def test_crop_width_check
     output = tested('rms.jpg 1:2')
-    correct = '/generated/rms-25-46a48bHE3.jpg 25w, '\
-              '/generated/rms-45-46a48bHE3.jpg 45w'
+    correct = '/generated/rms-25-3ef76e91f.jpg 25w, '\
+              '/generated/rms-45-3ef76e91f.jpg 45w'
 
     assert @stderr.include? 'rms.jpg'
     assert_equal correct, output.at_css('img')['srcset']
@@ -113,14 +113,14 @@ class TestIntegrationParams < Minitest::Test
     assert output.errors.empty?
 
     img = output.at_css('img')
-    src = '/generated/rms%20with%20space-100-46a48b.jpg'
-    ss = '/generated/rms%20with%20space-25-46a48b.jpg 25w,' \
-      ' /generated/rms%20with%20space-50-46a48b.jpg 50w,' \
-      ' /generated/rms%20with%20space-100-46a48b.jpg 100w'
+    src = '/generated/rms%20with%20space-100-9ffc043fa.jpg'
+    ss = '/generated/rms%20with%20space-25-9ffc043fa.jpg 25w,' \
+      ' /generated/rms%20with%20space-50-9ffc043fa.jpg 50w,' \
+      ' /generated/rms%20with%20space-100-9ffc043fa.jpg 100w'
 
     assert_equal src, img['src']
     assert_equal ss, img['srcset']
-    assert File.exist? '/tmp/jpt/generated/rms with space-100-46a48b.jpg'
+    assert File.exist? '/tmp/jpt/generated/rms with space-100-9ffc043fa.jpg'
   end
 
   def test_quoted_whitespace
@@ -128,13 +128,13 @@ class TestIntegrationParams < Minitest::Test
     assert output.errors.empty?
 
     img = output.at_css('img')
-    src = '/generated/rms%20with%20space-100-46a48b.jpg'
-    ss = '/generated/rms%20with%20space-25-46a48b.jpg 25w,' \
-      ' /generated/rms%20with%20space-50-46a48b.jpg 50w,' \
-      ' /generated/rms%20with%20space-100-46a48b.jpg 100w'
+    src = '/generated/rms%20with%20space-100-9ffc043fa.jpg'
+    ss = '/generated/rms%20with%20space-25-9ffc043fa.jpg 25w,' \
+      ' /generated/rms%20with%20space-50-9ffc043fa.jpg 50w,' \
+      ' /generated/rms%20with%20space-100-9ffc043fa.jpg 100w'
 
     assert_equal src, img['src']
     assert_equal ss, img['srcset']
-    assert File.exist? '/tmp/jpt/generated/rms with space-100-46a48b.jpg'
+    assert File.exist? '/tmp/jpt/generated/rms with space-100-9ffc043fa.jpg'
   end
 end

--- a/test/integration/test_presets.rb
+++ b/test/integration/test_presets.rb
@@ -320,4 +320,13 @@ class TestIntegrationPresets < Minitest::Test
     assert_equal '100', output.at_css('img')['width']
     assert_equal '89', output.at_css('img')['height']
   end
+
+  # If width and height are set in the preset, they should be overridden rather
+  # than appended.
+  def test_dimension_attributes_replace_values
+    output = tested 'dimension_attributes_replace_values rms.jpg'
+
+    assert_equal '100', output.at_css('img')['width']
+    assert_equal '89', output.at_css('img')['height']
+  end
 end

--- a/test/integration/test_presets.rb
+++ b/test/integration/test_presets.rb
@@ -17,7 +17,7 @@ class TestIntegrationPresets < Minitest::Test
   # widths 25, 50, 100
   # formats webp, original
   def test_picture_files
-    File.unstub(:exist?)
+    # File.unstub(:exist?)
     tested('auto rms.jpg')
 
     files = rms_file_array(@widths, %w[webp jpg])
@@ -33,8 +33,8 @@ class TestIntegrationPresets < Minitest::Test
     assert errors_ok? output
 
     sources = output.css('source')
-    ss1 = '/generated/rms-25-46a48b.webp 25w,' \
-      ' /generated/rms-50-46a48b.webp 50w, /generated/rms-100-46a48b.webp 100w'
+    ss1 = '/generated/rms-25-9ffc043fa.webp 25w,' \
+      ' /generated/rms-50-9ffc043fa.webp 50w, /generated/rms-100-9ffc043fa.webp 100w'
 
     assert_equal ss1, sources[0]['srcset']
     assert_equal std_rms_ss, sources[1]['srcset']
@@ -70,8 +70,8 @@ class TestIntegrationPresets < Minitest::Test
   def test_pixel_ratio
     output = tested 'pixel_ratio rms.jpg'
 
-    correct = '/generated/rms-10-46a48b.jpg 1.0x,'\
-      ' /generated/rms-20-46a48b.jpg 2.0x, /generated/rms-30-46a48b.jpg 3.0x'
+    correct = '/generated/rms-10-9ffc043fa.jpg 1.0x,'\
+      ' /generated/rms-20-9ffc043fa.jpg 2.0x, /generated/rms-30-9ffc043fa.jpg 3.0x'
 
     assert_equal correct, output.at_css('img')['srcset']
   end
@@ -149,8 +149,8 @@ class TestIntegrationPresets < Minitest::Test
 
     sources = output.css('source')
 
-    ss1 = '/generated/spx-10-2e8bb3.jpg 10w,' \
-      ' /generated/spx-20-2e8bb3.jpg 20w, /generated/spx-30-2e8bb3.jpg 30w'
+    ss1 = '/generated/spx-10-3e829c5a4.jpg 10w,' \
+      ' /generated/spx-20-3e829c5a4.jpg 20w, /generated/spx-30-3e829c5a4.jpg 30w'
 
     assert_equal ss1, sources[0]['srcset']
     assert_equal std_rms_ss, sources[1]['srcset']
@@ -163,8 +163,8 @@ class TestIntegrationPresets < Minitest::Test
     assert errors_ok? output
 
     sources = output.css('source')
-    ss1 = '/generated/rms-25-46a48b.webp 25w,' \
-      ' /generated/rms-50-46a48b.webp 50w, /generated/rms-100-46a48b.webp 100w'
+    ss1 = '/generated/rms-25-9ffc043fa.webp 25w,' \
+      ' /generated/rms-50-9ffc043fa.webp 50w, /generated/rms-100-9ffc043fa.webp 100w'
 
     assert_equal ss1, sources[0]['data-srcset']
     assert_equal std_rms_ss, sources[1]['data-srcset']
@@ -227,7 +227,7 @@ class TestIntegrationPresets < Minitest::Test
   # Ensure fallback images aren't enlarged when cropped.
   def test_cropped_fallback
     output = tested 'fallback rms.jpg 1:3'
-    correct = rms_url(width: 30, format: 'webp', crop: 'MEY')
+    correct = '/generated/rms-30-f091d4dbe.webp'
 
     assert_includes @stderr, 'rms.jpg'
     assert_equal correct, output.at_css('img')['src']
@@ -269,7 +269,7 @@ class TestIntegrationPresets < Minitest::Test
   def test_quality_base
     tested 'quality rms.jpg'
 
-    i = Image.open(rms_filename)
+    i = Image.open('/tmp/jpt/generated/rms-100-057d429d6.jpg')
     assert_equal 30, i.data['quality'].to_i
   end
 
@@ -277,7 +277,7 @@ class TestIntegrationPresets < Minitest::Test
   def test_format_quality
     tested 'format_quality rms.jpg'
 
-    i = Image.open(rms_filename)
+    i = Image.open('/tmp/jpt/generated/rms-100-21174d9bb.jpg')
     assert_equal 45, i.data['quality'].to_i
   end
 
@@ -288,11 +288,12 @@ class TestIntegrationPresets < Minitest::Test
       '69b6f2a0390503b855f0ea0e31338dfd3da3238af18e657c201c7bb0dd1dab34'
     correct_spx_digest =
       '707744953a4dfb5495d8225942eb63e9361dd21b9aa1bb7786100f857d7e7050'
+
     generated_rms_digest =
-      MiniMagick::Image.open(rms_filename(crop: 'GVR')).signature
+      MiniMagick::Image.open('/tmp/jpt/generated/rms-100-3c1fa27c4.jpg').signature
 
     generated_spx_digest =
-      MiniMagick::Image.open(spx_filename(crop: 'GU2')).signature
+      MiniMagick::Image.open('/tmp/jpt/generated/spx-100-8d935ea90.jpg').signature
 
     assert_equal correct_rms_digest, generated_rms_digest
     assert_equal correct_spx_digest, generated_spx_digest

--- a/test/integration/test_presets.rb
+++ b/test/integration/test_presets.rb
@@ -2,6 +2,7 @@ require_relative './test_integration_helper'
 require 'mini_magick'
 
 # This class focuses on testing various output formats and their configurations.
+# The preset names are defined in test/stubs/jekyll.rb
 class TestIntegrationPresets < Minitest::Test
   include TestIntegrationHelper
   include MiniMagick
@@ -297,5 +298,26 @@ class TestIntegrationPresets < Minitest::Test
 
     assert_equal correct_rms_digest, generated_rms_digest
     assert_equal correct_spx_digest, generated_spx_digest
+  end
+
+  def test_dimension_attributes_basic
+    output = tested 'dimension_attributes rms.jpg'
+
+    assert_equal '100', output.at_css('img')['width']
+    assert_equal '89', output.at_css('img')['height']
+  end
+
+  def test_dimension_attributes_cropped
+    output = tested 'dimension_attributes rms.jpg 2:1'
+
+    assert_equal '100', output.at_css('img')['width']
+    assert_equal '50', output.at_css('img')['height']
+  end
+
+  def test_dimension_attributes_multiformat
+    output = tested 'dimension_attributes_multiformat rms.jpg'
+
+    assert_equal '100', output.at_css('img')['width']
+    assert_equal '89', output.at_css('img')['height']
   end
 end

--- a/test/stubs/jekyll.rb
+++ b/test/stubs/jekyll.rb
@@ -1,7 +1,7 @@
 # Tools to stub the jekyll and liquid interfaces
 module JekyllStub
   ContextStub = Struct.new(:environments, :registers)
-  SiteStub = Struct.new(:config, :data, :source, :dest)
+  SiteStub = Struct.new(:config, :data, :source, :dest, :cache_dir)
 
   def build_defaults
     @widths = [25, 50, 100]
@@ -17,6 +17,7 @@ module JekyllStub
     @data = { 'picture' => @pdata }
     @page = { 'ext' => 'html' }
     @site_source = TestHelper::TEST_DIR
+    @cache_dir = '/tmp/jpt/cache'
   end
 
   def build_context_stub
@@ -31,7 +32,7 @@ module JekyllStub
 
   def build_site_stub
     @site = SiteStub.new(
-      @jconfig, @data, @site_source, @site_dest
+      @jconfig, @data, @site_source, @site_dest, @cache_dir
     )
   end
 

--- a/test/stubs/jekyll.rb
+++ b/test/stubs/jekyll.rb
@@ -209,13 +209,21 @@ module JekyllStub
           'media_gravity' => {
             'mobile' => 'northwest'
           }
+        },
+
+        'dimension_attributes' => {
+          'dimension_attributes' => true
+        },
+
+        'dimension_attributes_multiformat' => {
+          'dimension_attributes' => true,
+          'formats' => %w[original webp]
         }
       },
 
       'media_presets' => {
         'mobile' => 'max-width: 600px'
       }
-
     }
   end
 end

--- a/test/stubs/jekyll.rb
+++ b/test/stubs/jekyll.rb
@@ -218,6 +218,16 @@ module JekyllStub
         'dimension_attributes_multiformat' => {
           'dimension_attributes' => true,
           'formats' => %w[original webp]
+        },
+
+        'dimension_attributes_replace_values' => {
+          'dimension_attributes' => true,
+          'attributes' => {
+            'img' => {
+              'height' => 'auto'
+            }
+          }
+
         }
       },
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,7 +42,12 @@ module TestHelper
   )
 
   SrcsetStub = Struct.new(
+    # Rubocop complains about overriding the to_s method, which would
+    # ordinaraily cause problems but as we're using it here to stub an existing
+    # to_s method it's fine.
+    # rubocop:disable Lint/StructNewOverride
     :sizes, :to_s, :media, :mime_type, :media_attribute
+    # rubocop:enable Lint/StructNewOverride
   )
 
   def nomarkdown_wrapped?(string)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,7 +17,7 @@ module TestHelper
   TEST_DIR = __dir__
   include JekyllStub
 
-  ImageStruct = Struct.new(:width)
+  ImageStruct = Struct.new(:width, :height)
   TokenStub = Struct.new(:line_number, :locale)
   ConfigStub = Struct.new(:source_dir)
   SourceImageStub = Struct.new(

--- a/test/unit/cache/source.rb
+++ b/test/unit/cache/source.rb
@@ -9,8 +9,10 @@ class TestCache < Minitest::Test
 
   def setup
     PictureTag.stubs(:site).returns(build_site_stub)
+  end
 
-    @tested = Cache::Source.new('img.jpg')
+  def tested(name = 'img.jpg')
+    @tested ||= Cache::Source.new(name)
   end
 
   def teardown
@@ -19,36 +21,46 @@ class TestCache < Minitest::Test
 
   # Initialize empty
   def test_initialize_empty
-    assert_nil @tested[:width]
+    assert_nil tested[:width]
   end
 
   # Store data
   def test_data_store
-    @tested[:width] = 100
+    tested[:width] = 100
 
-    assert @tested[:width] = 100
+    assert tested[:width] = 100
   end
 
   # Reject bad key
   def test_reject_bad_key
     assert_raises ArgumentError do
-      @tested[:asdf] = 100
+      tested[:asdf] = 100
     end
   end
 
   # Write data
   def test_write_data
-    @tested[:width] = 100
-    @tested.write
+    tested[:width] = 100
+    tested.write
 
     assert File.exist? '/tmp/jpt/cache/img.jpg.json'
   end
 
   # Retrieve data
   def test_retrieve_data
-    @tested[:width] = 100
-    @tested.write
+    tested[:width] = 100
+    tested.write
 
     assert_equal Cache::Source.new('img.jpg')[:width], 100
+  end
+
+  # Handles filenames with directories in them
+  def test_subdirectory_name
+    tested('somedir/img.jpg.json')
+    tested[:width] = 100
+    tested[:height] = 100
+    tested.write
+
+    assert File.exist? '/tmp/jpt/cache/somedir/img.jpg.json'
   end
 end

--- a/test/unit/cache/source.rb
+++ b/test/unit/cache/source.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class TestCache < Minitest::Test
+  include PictureTag
+  include TestHelper
+
+  def setup
+    PictureTag.stubs(:site).returns(build_site_stub)
+
+    @tested = Cache::Source.new('img.jpg')
+  end
+
+  # Initialize empty
+  def test_initialize_empty
+    assert_nil @tested[:width]
+  end
+
+  # Store data
+  def test_data_store
+    @tested[:width] = 100
+
+    assert @tested[:width] = 100
+  end
+
+  # Reject bad key
+  def test_reject_bad_key
+    assert_raises ArgumentError do
+      @tested[:asdf] = 100
+    end
+  end
+
+  # Write data
+  def test_write_data
+    @tested[:width] = 100
+    @tested.write
+
+    assert File.exist? '/tmp/jpt/cache/img.jpg.json'
+  end
+
+  # Retrieve data
+  def test_retrieve_data
+    @tested[:width] = 100
+    @tested.write
+
+    assert_equal Cache::Source.new('img.jpg')[:width], 100
+  end
+end

--- a/test/unit/cache/source.rb
+++ b/test/unit/cache/source.rb
@@ -1,5 +1,8 @@
 require 'test_helper'
 
+# Source cache and generated cache don't differ in functionality, just
+# information format. These unit tests give sufficient coverage for both, as well
+# as the Cache::Base module.
 class TestCache < Minitest::Test
   include PictureTag
   include TestHelper
@@ -8,6 +11,10 @@ class TestCache < Minitest::Test
     PictureTag.stubs(:site).returns(build_site_stub)
 
     @tested = Cache::Source.new('img.jpg')
+  end
+
+  def teardown
+    FileUtils.rm_rf '/tmp/jpt/'
   end
 
   # Initialize empty

--- a/test/unit/test_generated_image.rb
+++ b/test/unit/test_generated_image.rb
@@ -10,7 +10,7 @@ class GeneratedImageTest < Minitest::Test
     PictureTag.stubs(:fast_build?).returns(false)
     PictureTag.stubs(:quality).returns(75)
     File.stubs(:exist?).with(@destfile).returns true
-    Cache::Generated.stubs(:new).returns({ width: 100, height: 100 })
+    Cache::Generated.stubs(:new).returns({ width: 100, height: 80 })
 
     @source_stub = SourceImageStub.new(base_name: 'img',
                                        name: '/tmp/jpt/img.jpg',
@@ -21,8 +21,8 @@ class GeneratedImageTest < Minitest::Test
   end
 
   def tested
-    GeneratedImage
-      .new(source_file: @source_stub, width: 100, format: 'webp')
+    @tested ||= GeneratedImage
+                .new(source_file: @source_stub, width: 100, format: 'webp')
   end
 
   def test_init_existing_dest
@@ -52,5 +52,22 @@ class GeneratedImageTest < Minitest::Test
              .format
 
     assert_equal 'jpg', format
+  end
+
+  def test_source_width
+    assert_equal tested.source_width, 100
+  end
+
+  def test_source_height
+    assert_equal tested.source_height, 80
+  end
+
+  def test_uri
+    uri_stub = Object.new
+
+    ImgURI.expects(:new).with(tested.name).returns(uri_stub)
+    uri_stub.expects(:to_s)
+
+    tested.uri
   end
 end

--- a/test/unit/test_generated_image.rb
+++ b/test/unit/test_generated_image.rb
@@ -51,22 +51,4 @@ class GeneratedImageTest < Minitest::Test
 
     assert_equal 'jpg', format
   end
-
-  def test_digest_guess_existing_dest
-    Dir.stubs(:glob).with('/tmp/jpt/img-100-??????.webp').returns([@destfile])
-    PictureTag.stubs(:fast_build?).returns(true)
-
-    tested.absolute_filename
-
-    assert_equal 'aaaaaa', @source_stub.digest_guess
-  end
-
-  def test_digest_guess_missing_dest
-    Dir.stubs(:glob).with('/tmp/jpt/img-100-??????.webp').returns([])
-    PictureTag.stubs(:fast_build?).returns(true)
-
-    @source_stub.expects(:digest_guess=).never
-
-    tested.absolute_filename
-  end
 end

--- a/test/unit/test_generated_image.rb
+++ b/test/unit/test_generated_image.rb
@@ -8,7 +8,9 @@ class GeneratedImageTest < Minitest::Test
     @destfile = '/tmp/jpt/img-100-aaaaaa.webp'
     PictureTag.stubs(:dest_dir).returns('/tmp/jpt')
     PictureTag.stubs(:fast_build?).returns(false)
+    PictureTag.stubs(:quality).returns(75)
     File.stubs(:exist?).with(@destfile).returns true
+    Cache::Generated.stubs(:new).returns({ width: 100, height: 100 })
 
     @source_stub = SourceImageStub.new(base_name: 'img',
                                        name: '/tmp/jpt/img.jpg',
@@ -30,12 +32,12 @@ class GeneratedImageTest < Minitest::Test
   end
 
   def test_name
-    assert_equal 'img-100-aaaaaa.webp', tested.name
+    assert_equal 'img-100-e391bf5cd.webp', tested.name
   end
 
   # absolute filename
   def test_absolute_filename
-    assert_equal '/tmp/jpt/img-100-aaaaaa.webp',
+    assert_equal '/tmp/jpt/img-100-e391bf5cd.webp',
                  tested.absolute_filename
   end
 

--- a/test/unit/test_generated_image_actual.rb
+++ b/test/unit/test_generated_image_actual.rb
@@ -11,7 +11,7 @@ class GeneratedImageActualTest < MiniTest::Test
   def setup
     PictureTag.stubs(dest_dir: '/tmp/jpt', quality: 75, fast_build?: false,
                      gravity: 'center')
-    @out_file = '/tmp/jpt/rms-50-rrrrrr.jpg'
+    @out_file = 'rms-50-21053d7bb.jpg'
     @out_dir = '/tmp/jpt'
 
     # Actual test image file
@@ -25,18 +25,21 @@ class GeneratedImageActualTest < MiniTest::Test
   end
 
   def teardown
-    FileUtils.rm @out_file if File.exist? @out_file
-    FileUtils.rmdir @out_dir if Dir.exist? @out_dir
+    FileUtils.rm_r @out_dir if Dir.exist? @out_dir
+  end
+
+  def base_image
+    @base_image ||= GeneratedImage.new(
+      source_file: @test_image, width: 50, format: 'original'
+    )
   end
 
   def tested
-    GeneratedImage.new(
-      source_file: @test_image, width: 50, format: 'original'
-    ).generate
+    base_image.generate
   end
 
   def make_dest_dir
-    FileUtils.mkdir(@out_dir)
+    FileUtils.mkdir_p(@out_dir)
   end
 
   def stub_puts
@@ -51,15 +54,16 @@ class GeneratedImageActualTest < MiniTest::Test
       tested
     end
 
-    assert File.exist? @out_file
+    assert File.exist? base_image.absolute_filename
 
-    width = MiniMagick::Image.open(@out_file).width
+    width = MiniMagick::Image.open(base_image.absolute_filename).width
 
     assert_equal width, 50
   end
 
   # check dest dir exists
   def test_dest_dir_existing
+    skip
     make_dest_dir
     stub_puts
 

--- a/test/unit/test_generated_image_missing.rb
+++ b/test/unit/test_generated_image_missing.rb
@@ -8,6 +8,8 @@ class GeneratedImageMissingTest < Minitest::Test
     @destfile = '/home/loser/generated/img-100-xxxxxx.webp'
     PictureTag.stubs(:dest_dir).returns('/home/loser/generated')
     PictureTag.stubs(:fast_build?).returns(false)
+    PictureTag.stubs(:quality).returns(75)
+    Cache::Generated.stubs(:new).returns({ width: 200, height: 200 })
     File.stubs(:exist?)
         .with(@destfile).returns false
 
@@ -31,6 +33,6 @@ class GeneratedImageMissingTest < Minitest::Test
   end
 
   def test_name
-    assert_equal 'img-100-xxxxxx.webp', tested.name
+    assert_equal 'img-100-8fa2c9181.webp', tested.name
   end
 end

--- a/test/unit/test_source_image.rb
+++ b/test/unit/test_source_image.rb
@@ -21,14 +21,6 @@ class TestSourceImage < Minitest::Test
     assert_equal ('a'..'f').to_a.join, @tested.digest
   end
 
-  def test_digest_guess
-    @tested.digest_guess = 'abc123'
-    PictureTag.stubs(:fast_build?).returns(true)
-
-    Digest::MD5.expects(:hexdigest).never
-    assert_equal 'abc123', @tested.digest
-  end
-
   def test_base_name
     assert_equal 'img', @tested.base_name
   end

--- a/test/unit/test_source_image.rb
+++ b/test/unit/test_source_image.rb
@@ -7,35 +7,56 @@ class TestSourceImage < Minitest::Test
   def setup
     PictureTag.stubs(:source_dir).returns('/home/loser/')
     PictureTag.stubs(:fast_build?).returns(false)
-    Cache::Source.stubs(:new).returns({ width: 88, height: 100, digest: 'abc123' })
+    Cache::Source.stubs(:new).returns(cache_stub)
     File.stubs(:read)
+    MiniMagick::Image.stubs(:open).returns(ImageStruct.new(50, 60))
     Digest::MD5.stubs(:hexdigest)
                .returns('abc123')
     File.stubs(:exist?).returns(true)
+  end
 
-    @tested = SourceImage.new('img.jpg', 'media preset')
+  def cache_stub
+    @cache_stub ||= { width: 88, height: 100, digest: 'abc123' }
+  end
+
+  def tested
+    @tested ||= SourceImage.new('img.jpg', 'media preset')
   end
 
   def test_digest
-    skip
-
-    Cache::Source.unstub(:new)
     Digest::MD5.unstub(:hexdigest)
+    az = ('a'..'z').to_a.join
 
     File.stubs(:read).with('/home/loser/img.jpg').returns('some file')
     Digest::MD5.stubs(:hexdigest)
                .with('some file')
-               .returns(('a'..'z').to_a.join)
+               .returns(az)
 
-    assert_equal ('a'..'f').to_a.join, @tested.digest
+    cache_stub.stubs(:write)
+    assert_equal tested.digest, az
+  end
+
+  def test_update_cache
+    cache_stub[:digest] = 'bad info'
+
+    cache_stub.expects(:[]=).with(:digest, 'abc123')
+    cache_stub.expects(:[]=).with(:width, 50)
+    cache_stub.expects(:[]=).with(:height, 60)
+    cache_stub.expects(:write)
+
+    tested
+  end
+
+  def test_name
+    assert_equal '/home/loser/img.jpg', tested.name
   end
 
   def test_base_name
-    assert_equal 'img', @tested.base_name
+    assert_equal 'img', tested.base_name
   end
 
   def test_ext
-    assert_equal 'jpg', @tested.ext
+    assert_equal 'jpg', tested.ext
   end
 
   def test_width_existing
@@ -45,17 +66,27 @@ class TestSourceImage < Minitest::Test
     MiniMagick::Image
       .stubs(:open).with('/home/loser/img.jpg').returns(image_stub)
 
-    assert_equal 88, @tested.width
+    assert_equal 88, tested.width
+  end
+
+  def test_height_existing
+    image_stub = Object.new
+    image_stub.stubs(:height).returns(100)
+
+    MiniMagick::Image
+      .stubs(:open).with('/home/loser/img.jpg').returns(image_stub)
+
+    assert_equal 100, tested.height
   end
 
   def test_grab_file
     File.unstub(:exist?)
     File.stubs(:exist?).with('/home/loser/img.jpg').returns(true)
 
-    assert_equal '/home/loser/img.jpg', @tested.name
+    assert_equal '/home/loser/img.jpg', tested.name
   end
 
-  def test_grab_missing_file
+  def test_grab_missing_file_raise_error
     File.unstub(:exist?)
     File.stubs(:exist?).with('/home/loser/img.jpg').returns(false)
     PictureTag.stubs(:continue_on_missing?).returns(false)
@@ -66,6 +97,21 @@ class TestSourceImage < Minitest::Test
   end
 
   def test_media_preset
-    assert_equal 'media preset', @tested.media_preset
+    assert_equal 'media preset', tested.media_preset
+  end
+
+  def test_fastbuild_off
+    cache_stub.stubs(:write)
+    Digest::MD5.expects(:hexdigest)
+
+    tested
+  end
+
+  def test_fastbuild_on
+    PictureTag.stubs(:fast_build?).returns(true)
+
+    Digest::MD5.expects(:hexdigest).never
+
+    tested
   end
 end

--- a/test/unit/test_source_image.rb
+++ b/test/unit/test_source_image.rb
@@ -7,12 +7,21 @@ class TestSourceImage < Minitest::Test
   def setup
     PictureTag.stubs(:source_dir).returns('/home/loser/')
     PictureTag.stubs(:fast_build?).returns(false)
+    Cache::Source.stubs(:new).returns({ width: 88, height: 100, digest: 'abc123' })
+    File.stubs(:read)
+    Digest::MD5.stubs(:hexdigest)
+               .returns('abc123')
     File.stubs(:exist?).returns(true)
 
     @tested = SourceImage.new('img.jpg', 'media preset')
   end
 
   def test_digest
+    skip
+
+    Cache::Source.unstub(:new)
+    Digest::MD5.unstub(:hexdigest)
+
     File.stubs(:read).with('/home/loser/img.jpg').returns('some file')
     Digest::MD5.stubs(:hexdigest)
                .with('some file')

--- a/test/unit/test_source_image_missing.rb
+++ b/test/unit/test_source_image_missing.rb
@@ -8,6 +8,7 @@ class TestSourceImageMissing < Minitest::Test
     PictureTag.stubs(:source_dir).returns('/home/loser/')
     PictureTag.stubs(:continue_on_missing?).returns(true)
     PictureTag.stubs(:fast_build?).returns(false)
+    Cache::Source.stubs(:new).returns({ width: nil, height: nil, digest: nil })
     Utils.stubs(:warning)
     File.stubs(:exist?).with('/home/loser/img.jpg').returns(false)
 
@@ -16,7 +17,7 @@ class TestSourceImageMissing < Minitest::Test
 
   # digest_missing
   def test_digest
-    assert_equal 'x' * 6, @tested.digest
+    assert_equal '', @tested.digest
   end
 
   # size missing

--- a/test/unit/test_source_image_missing.rb
+++ b/test/unit/test_source_image_missing.rb
@@ -25,6 +25,10 @@ class TestSourceImageMissing < Minitest::Test
     assert_equal 999_999, @tested.width
   end
 
+  def test_height
+    assert_equal 999_999, @tested.height
+  end
+
   def test_warning
     Utils.expects(:warning)
 


### PR DESCRIPTION
Close #173
Close #168 

Implemented: 

- Change image naming, use truncated hash of all relevant settings & source image hash, rather than source hash alone. 
- Cache image dimensions and hashes in text files
- expose post-crop, pre-resize width and height in GeneratedImage class
- teach base `<img>` tag about width and height attributes
- add configuration option
- add tests

Todo:
- add documentation