### PR TITLE
Proof on concept for SVG placeholder markup

### DIFF
--- a/lib/jekyll_picture_tag/output_formats/data_attributes.rb
+++ b/lib/jekyll_picture_tag/output_formats/data_attributes.rb
@@ -9,8 +9,9 @@ module PictureTag
 
       private
 
+
       def add_src(element, uri)
-        element.attributes << { 'data-src' => uri }
+        element.attributes << { 'src="data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 3 2\'%3E%3C/svg%3E" data-src' => uri }
       end
 
       def add_srcset(element, srcset)

--- a/lib/jekyll_picture_tag/output_formats/data_attributes.rb
+++ b/lib/jekyll_picture_tag/output_formats/data_attributes.rb
@@ -10,8 +10,14 @@ module PictureTag
       private
 
 
+      def foo
+        @srcset ||= build_srcset(
+          PictureTag.source_images.first, PictureTag.formats.first
+        )
+      end
+
       def add_src(element, uri)
-        element.attributes << { 'src="data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 3 2\'%3E%3C/svg%3E" data-src' => uri }
+        element.attributes << { src: "data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 "+foo.width_attribute+" "+foo.height_attribute+"\'%3E%3C/svg%3E", 'data-src' => uri }
       end
 
       def add_srcset(element, srcset)


### PR DESCRIPTION
**NOTE:** This PR is not intended for production code! 

This is a proof of concept for #149. It (rather horribly) hard-codes the SVG placeholder markup into the “data attributes” output format option. 


