### PR TITLE
merge presets with user-provided defaults

### DIFF
--- a/lib/jekyll_picture_tag/parsers/preset.rb
+++ b/lib/jekyll_picture_tag/parsers/preset.rb
@@ -15,7 +15,15 @@ module PictureTag
       protected
 
       def content
-        @content ||= default_preset.merge settings
+        @content ||= begin
+          content = settings
+          parents = [content["inherit"]].flatten.compact.map do |base|
+            PictureTag.site.data.dig('picture', 'presets', base) || no_preset(base)
+          end
+          parents.reduce DEFAULT_PRESET.merge(content) do |child, parent|
+            Jekyll::Utils.deep_merge_hashes(parent, child)
+          end
+        end
       end
 
       private
@@ -31,7 +39,7 @@ module PictureTag
         @default ||= DEFAULT_PRESET.merge( PictureTag.site.data.dig('picture', 'presets', 'default') || {})
       end
 
-      def no_preset
+      def no_preset(name=@name)
         unless name == 'default'
           Utils.warning(
             <<~HEREDOC

--- a/lib/jekyll_picture_tag/parsers/preset.rb
+++ b/lib/jekyll_picture_tag/parsers/preset.rb
@@ -15,7 +15,7 @@ module PictureTag
       protected
 
       def content
-        @content ||= DEFAULT_PRESET.merge settings
+        @content ||= default_preset.merge settings
       end
 
       private
@@ -24,6 +24,11 @@ module PictureTag
         PictureTag.site.data.dig('picture', 'presets', name) ||
           STOCK_PRESETS[name] ||
           no_preset
+      end
+
+      def default_preset
+        return DEFAULT_PRESET if name == 'default'
+        @default ||= DEFAULT_PRESET.merge( PictureTag.site.data.dig('picture', 'presets', 'default') || {})
       end
 
       def no_preset

--- a/test/unit/parsers/test_preset.rb
+++ b/test/unit/parsers/test_preset.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+class PresetTest < Minitest::Test
+  include PictureTag
+  include TestHelper
+
+  def test_merge
+    formats = ["jpeg", "webp"]
+    original = PictureTag.site.data["picture"]["presets"]["img"]
+    PictureTag.site.data["picture"]["presets"]["default"]['formats'] = formats
+    preset = Parsers::Preset.new "img"
+    assert_equal preset['formats'], formats
+    PictureTag.site.data["picture"]["presets"]["default"].each do | key, value|
+      if original.has_key?(key)
+        assert_equal preset[key], original[key]
+      else
+        assert_equal preset[key], value
+      end
+    end
+  end
+
+  def test_merge_gem_defaults
+    original = PictureTag.site.data["picture"]["presets"]["img"]
+    PictureTag.site.data["picture"]["presets"].delete "default"
+
+    preset = Parsers::Preset.new "img"
+    assert_equal preset['formats'], ["original"]
+    DEFAULT_PRESET.each do | key, value|
+      if original.has_key?(key)
+        assert_equal preset[key], original[key]
+      else
+        assert_equal preset[key], value
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently `PictureTag::Parsers::Preset` is merging all presets with `DEFAULT_PRESET`, it could merge the Gem's defaults with `Site.data.picture.presets.default`. Allowing users to have smaller **picture.yml** files by providing custom site-wide defaults.

The change doesn't break any tests but would of course be a breaking change that require a major version bump. However this behavior feels quite natural to me : many tools have a way to supply user defaults that are inherited by other presets.

It might be possible to make it non-breaking by creating a new section in `picture.yml`, thus accessing the *site-wide-defaults* with `PictureTag.site.data.dig("picture","defaults")`. I'm open to take whatever path the maintainer or other users feel preferable.

Additionally, I created some basic tests which are probably crap, sorry about this, I wasn't able to do any better.
