### PR TITLE
Implement a threadpool for faster builds.

### DIFF
--- a/jekyll_picture_tag.gemspec
+++ b/jekyll_picture_tag.gemspec
@@ -29,6 +29,8 @@ Gem::Specification.new do |spec|
 
   # addressable is used to url-encode image filenames.
   spec.add_runtime_dependency 'addressable', '~> 2.6'
+  # Needed for parallel excution of builds.
+  spec.add_runtime_dependency 'concurrent-ruby', '~> 1.1'
   # Jekyll versions older than 4.0 are not supported.
   spec.add_runtime_dependency 'jekyll', '~> 4.0'
   # MIME types are needed for <source> tags' type= attributes.


### PR DESCRIPTION
Fixes #225

Uses `Concurrent::ThreadPoolExecutor` from [concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby) to avoid memory blowup, and de-duplicates files before generation so we no longer need to rely on filesystem consistency to avoid double-generating images.

In my experience on a 4 core/8 thread system, this optimization halves my build times.