### PR TITLE
Add libvips-tools requirements in Gemspec

### DIFF
--- a/jekyll_picture_tag.gemspec
+++ b/jekyll_picture_tag.gemspec
@@ -42,6 +42,8 @@ Gem::Specification.new do |spec|
 
   # libvips handles all image processing operations.
   spec.requirements << 'libvips'
+  # To call the `vips` command-line utility
+  spec.requirements << 'libvips-tools'
 
   # Development dependencies are not installed when using this gem. You can
   # ignore these, unless you are working on JPT itself.


### PR DESCRIPTION
Hi,

As the gem actually requires the `vips` CLI to be installed, I'm suggesting the Gemspec list this requirements. 

Thanks