### PR TITLE
Fix: Ignore unsupported quality parameter for PPM files

### DIFF
--- a/lib/jekyll_picture_tag/images/image_file.rb
+++ b/lib/jekyll_picture_tag/images/image_file.rb
@@ -57,9 +57,9 @@ module PictureTag
 
       opts[:strip] = PictureTag.preset['strip_metadata']
 
-      # gifs don't accept a quality setting, and PNGs don't on older versions of
+      # gifs don't accept a quality setting, and PNGs and PPMs don't on older versions of
       # vips. Since it's not remarkably useful anyway, we'll ignore them.
-      opts[quality_key] = base.quality unless %w[gif png].include? base.format
+      opts[quality_key] = base.quality unless %w[gif png ppm].include? base.format
 
       opts.transform_keys(&:to_sym)
     end


### PR DESCRIPTION
Using PPM files were giving errors as vips does not support -Q (quality) parameter.

```
vips VipsForeignSavePpmFile 
save image to ppm file
usage:
   ppmsave in filename [--option-name option-value ...]
where:
   in           - Image to save, input VipsImage
   filename     - Filename to save to, input gchararray
optional arguments:
   format       - Format to save in, input VipsForeignPpmFormat
			default enum: ppm
			allowed enums: pbm, pgm, ppm, pfm, pnm
   ascii        - Save as ascii, input gboolean
			default: false
   bitdepth     - Set to 1 to write as a 1 bit image, input gint
			default: 0
			min: 0, max: 1
   keep         - Which metadata to retain, input VipsForeignKeep
			default flags: exif:xmp:iptc:icc:other:all
			allowed flags: none, exif, xmp, iptc, icc, other, all
   background   - Background value, input VipsArrayDouble
   page-height  - Set page height for multipage save, input gint
			default: 0
			min: 0, max: 10000000
   profile      - Filename of ICC profile to embed, input gchararray
operation flags: sequential nocache 

```

So just ignore it like we do with png files.

[related issue](https://github.com/rbuchberger/jekyll_picture_tag/issues/308)