### PR TITLE
Update requirements for ruby-vips

### DIFF
--- a/jekyll_picture_tag.gemspec
+++ b/jekyll_picture_tag.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   # rainbow is used to colorize terminal output.
   spec.add_runtime_dependency 'rainbow', '~> 3.0'
   # ruby-vips interfaces with libvips.
-  spec.add_runtime_dependency 'ruby-vips', '~> 2.0.17'
+  spec.add_runtime_dependency 'ruby-vips', '~> 2.2'
 
   # libvips handles all image processing operations.
   spec.requirements << 'libvips'


### PR DESCRIPTION
I ran into a slight issue when installing another gem, `jekyll-og-image`, due to conflicting `ruby-vips` versions.

```
bundle add jekyll-og-image
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Could not find compatible versions

Because every version of jekyll-og-image depends on ruby-vips ~> 2.2.0
  and jekyll_picture_tag >= 2.0.0pre1 depends on ruby-vips ~> 2.0.17,
  every version of jekyll-og-image is incompatible with jekyll_picture_tag >= 2.0.0pre1.
So, because Gemfile depends on jekyll_picture_tag ~> 2.1
  and Gemfile depends on jekyll-og-image >= 0,
  version solving has failed.
```

Since ruby-vips latest version is now 2.2 I believe the most straightforward fix here is to update `jekyll_picture_tag` to use this  version. I'd also be happy to use any other constraints that you deem fit (e.g. could see `~> 2, >= 2.0.17` also working well).