### PR TITLE
Document anchor/alias functionality

### DIFF
--- a/docs/users/presets/subpresets.md
+++ b/docs/users/presets/subpresets.md
@@ -1,0 +1,97 @@
+---
+sort: 15
+---
+
+# Aliases & Subpresets
+
+If you're making more than one preset, you probably have things you'd prefer to not copy to every preset. Maybe some finely tuned quality settings, or different variations and crops. Thankfully, YAML has an anchor & alias feature to help with this.
+
+Anchors are defined with a `&` and a name, placed after a key, but before the value. For the sake of example, we've defined a quality for JPEG, and given it the anchor "high_quality".
+
+```yml
+  default: 
+    format_quality:
+      jpg: &high_quality 90
+```
+
+With our anchor added, we can refer back to it with an alias. These are in the same format, but we use a `*` instead. (and we don't place a value, since we're making the alias our value!)
+
+```yml
+  logo: 
+    format_quality:
+      jpg: *high_quality
+```
+
+Now any time we change our default quality, the quality in the logo preset will be updated too!
+
+
+## Subpresets
+
+Where this feature really gets powerful, is the ability to base a preset entirely off another.
+
+In the block below, we've created a base preset, which we'll build every other one upon. We can override any of the values later on, if we want to.
+
+```yml
+  base: &base
+    formats: [webp, original]
+    format_quality:
+      webp: 90
+    attributes:
+      img: 'loading="lazy"'
+```
+
+Now we can use the special merge key, `<<`, which will copy all values from an aliased map into the new one.
+
+```yml
+  default:
+    <<: *base
+    widths: [500, 600, 700, 800, 900, 1000, 1200, 1600]
+    link_source: true
+
+  project_showcase:
+    <<: *base
+    widths: [700, 864, 900, 1296, 1600, 1728]
+```
+
+Since both of these new presets merge our base preset, the final result will be parsed like this:
+
+```yml
+  default:
+    formats: [webp, original]
+    format_quality:
+      webp: 90
+    attributes:
+      img: 'loading="lazy"'
+    widths: [500, 600, 700, 800, 900, 1000, 1200, 1600]
+    link_source: true
+
+  project_showcase:
+    formats: [webp, original]
+    format_quality:
+      webp: 90
+    attributes:
+      img: 'loading="lazy"'
+    widths: [700, 864, 900, 1296, 1600, 1728]
+```
+
+Note however, this is **not a deep merge**, only a shallow merge. What that means is, any values nested in the preset will be overwritten by the presence of a key. If we bring back our previous example, but add an attribute to it:
+
+```yml
+  project_showcase:
+    <<: *base
+    widths: [700, 864, 900, 1296, 1600, 1728]
+    attributes:
+      picture: 'class="showcase"'
+```
+
+You'll notice that, although we didn't change the `img` attributes, the parsed result will be **missing the attributes from the parent preset**, like this:
+
+```yml
+  project_showcase:
+    formats: [webp, original]
+    format_quality:
+      webp: 90
+    attributes:
+      picture: 'class="showcase"'
+    widths: [700, 864, 900, 1296, 1600, 1728]
+```


### PR DESCRIPTION
After seeing the conversation in #271, I decided to quickly go in and document this for people to find easier. I didn't find this syntax very intuitive at first, and it took me a while to wrap my head around it. I wouldn't expect a more casual user to catch on immediately, so I tried to explain it in the most clear way I could, making no assumptions. I also coined the term "subpreset" for this, primarily because it makes it very obvious when skimming the pages list if you're trying to find a feature like this, but also I just thought it sounded cool :p

As a side note, you might wanna update some things to make it easier to contribute to the docs. The theme `rundocs/jekyll-rtd-theme` appears to have disappeared, alongside the entire rundocs account. No idea what happened, but using a reupload by setting `remote_theme: clearpathrobotics/jekyll-rtd-theme@main` fixed the problem. Although, I also had to nuke the `Gemfile.lock` file, let it generate a new one, then manually change the two instances of jekyll from `3.9.0` to `3.9.2`. Some weird old bug involving updating to Ruby 3. I'm unfamiliar with Gemfiles and such, but that doesn't feel like a real solution, so I didn't wanna try to PR that. Especially because I also couldn't `jekyll serve`, something about webrick... but at that point, the site had built, and opening the file directly was good enough to preview my changes.