### PR TITLE
Fix broken documentation

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,5 +2,4 @@ source 'https://rubygems.org'
 
 group :jekyll_plugins do
   gem 'github-pages'
-  gem 'jekyll-rtd-theme'
 end

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -136,8 +136,6 @@ GEM
       addressable (~> 2.0)
       jekyll (>= 3.5, < 5.0)
       rubyzip (>= 1.3.0)
-    jekyll-rtd-theme (0.1.6)
-      github-pages (~> 206)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-seo-tag (2.6.1)
@@ -245,7 +243,6 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
-  jekyll-rtd-theme
 
 BUNDLED WITH
    2.1.4

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,9 +1,9 @@
-remote_theme: rundocs/jekyll-rtd-theme
+remote_theme: rbuchberger/jekyll-rtd-theme@main
 
 title: Jekyll Picture Tag
 description: Images for Jekyll, done correctly.
 lang: en-US
 
 baseurl: '/jekyll_picture_tag'
-readme_index: 
+readme_index:
   with_frontmatter: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "jekyll_picture_tag",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Whoever was hosting the original RTD theme took down the repo, which is a bit of a jerk move.

Someone else reuploaded it, and I've made my own fork to ensure this doesn't happen again.