### PR TITLE
JPT for Windows

### DIFF
--- a/docs/users/presets/image_formats.md
+++ b/docs/users/presets/image_formats.md
@@ -17,5 +17,5 @@ used**. `original` does what you'd expect. To supply webp, you must have an
 imagemagick webp delegate installed. (Most package managers just name it 'webp')
 
 _Supported formats are anything which imagemagick supports, and has an installed
-delegate. See a list by running `$ convert --version`_.
+delegate. See a list by running `$ magick --version`_.
 

--- a/lib/jekyll_picture_tag/parsers/image_backend.rb
+++ b/lib/jekyll_picture_tag/parsers/image_backend.rb
@@ -34,6 +34,12 @@ module PictureTag
                               .first
                               .delete_prefix('Delegates (built-in):')
                               .split
+        elsif command?('convert')
+          @magick_formats ||= `convert -version`
+                              .scan(/Delegates.*/)
+                              .first
+                              .delete_prefix('Delegates (built-in):')
+                              .split
         else
           @magick_formats = []
         end
@@ -56,7 +62,7 @@ module PictureTag
                else
                  'Libvips is not installed.'
                end
-        str << if command?('magick')
+        str << if command?('magick') || command?('convert')
                  "Imagemagick (installed) supports: \"#{magick_formats.join(', ')}\"."
                else
                  'Imagemagick is not installed.'

--- a/lib/jekyll_picture_tag/parsers/image_backend.rb
+++ b/lib/jekyll_picture_tag/parsers/image_backend.rb
@@ -69,7 +69,12 @@ module PictureTag
       end
 
       def command?(command)
-        system("which #{command} > /dev/null 2>&1")
+        is_windows = RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+        if is_windows
+          system("where #{command} > NUL 2>&1")
+        else
+          system("which #{command} > /dev/null 2>&1")
+        end
       end
     end
   end

--- a/lib/jekyll_picture_tag/parsers/image_backend.rb
+++ b/lib/jekyll_picture_tag/parsers/image_backend.rb
@@ -28,8 +28,8 @@ module PictureTag
 
       # Returns an array of formats that imagemagick can handle.
       def magick_formats
-        if command?('convert')
-          @magick_formats ||= `convert -version`
+        if command?('magick')
+          @magick_formats ||= `magick -version`
                               .scan(/Delegates.*/)
                               .first
                               .delete_prefix('Delegates (built-in):')
@@ -56,7 +56,7 @@ module PictureTag
                else
                  'Libvips is not installed.'
                end
-        str << if command?('convert')
+        str << if command?('magick')
                  "Imagemagick (installed) supports: \"#{magick_formats.join(', ')}\"."
                else
                  'Imagemagick is not installed.'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,7 +49,7 @@ module TestHelper
   # them doesn't support some image format. This returns an array of image
   # formats which we care about, and which are locally supported.
   def supported_formats
-    output = `vips --list` + `convert --version`
+    output = `vips --list` + `magick --version`
 
     formats = %w[jpg png webp gif jp2 avif].select do |format|
       output.include? format

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,7 +49,8 @@ module TestHelper
   # them doesn't support some image format. This returns an array of image
   # formats which we care about, and which are locally supported.
   def supported_formats
-    output = `vips --list` + `magick --version`
+    magick_command = command?('magick') ? `magick` : `convert`
+    output = `vips --list` + `#{magick_command} --version`
 
     formats = %w[jpg png webp gif jp2 avif].select do |format|
       output.include? format
@@ -59,5 +60,14 @@ module TestHelper
     raise 'Not enough locally supported formats' unless formats.length >= 3
 
     formats
+  end
+
+  def command?(command)
+    is_windows = RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+    if is_windows
+      system("where #{command} > NUL 2>&1")
+    else
+      system("which #{command} > /dev/null 2>&1")
+    end
   end
 end


### PR DESCRIPTION
# Contents
- Replaced `convert` with `magick` (Fixes #321)
- Added Selection to `command?` function to use `where` on windows (Fixes #303)

# Continuation of #322

I tried to rebase, not really a pro at git either so I ended up nerfing the previous PR. This is the new PR, it doesn't have the Standalone Imagemagick edits and is ready to merge.

I haven't tested just yet, I'm installing VIPS and will test it soon. Logically speaking the code should work as I have only removed some edits and not made any new ones.